### PR TITLE
Feat#6  디테일페이지 기능개선 외

### DIFF
--- a/src/components/detailpage/ContentOverview.tsx
+++ b/src/components/detailpage/ContentOverview.tsx
@@ -11,7 +11,7 @@ const ContentOverview: React.FC<ContentOverviewProps> = ({ overview }) => {
     setShowMore(!showMore);
   };
 
-  const formattedOverview = splitText(overview, 50);
+  const formattedOverview = splitText(overview, 70);
 
   return (
     <section className="w-full max-w-[1440px] mt-4 text-left py-12">

--- a/src/components/detailpage/DetailPageAddComment.tsx
+++ b/src/components/detailpage/DetailPageAddComment.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { fetchSessionData } from "@/utils/fetchSession";
 import { createClient } from "@/utils/supabase/client";
 import { Session } from "@supabase/supabase-js";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import Image from "next/image";
 import { useState } from "react";
+import { fetchSessionData } from "./../../utils/auth";
+import CommentForm from "./addcomment/CommentForm";
 
 const supabase = createClient();
 
@@ -59,6 +60,9 @@ const DetailPageAddComment: React.FC<DetailPageAddCommentProps> = ({ userId, con
   const handleAddComment = () => {
     addCommentMutation.mutate();
   };
+  const handleCommentChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setComment(event.target.value);
+  };
 
   if (isPending) {
     return <div>불러오는중...</div>;
@@ -79,26 +83,12 @@ const DetailPageAddComment: React.FC<DetailPageAddCommentProps> = ({ userId, con
           <span className="text-2xl font-bold ml-2 text-grey-700">{sessionData.user.email} 님</span>
         </div>
       )}
-      <div className="p-4 border border-primary-100 rounded-xl flex items-center bg-grey-50 py-12">
-        <textarea
-          value={comment}
-          onChange={(event) => setComment(event.target.value)}
-          placeholder={userId ? "댓글을 작성하세요" : "댓글 작성은 로그인한 유저만 가능합니다"}
-          className={`w-full p-2 rounded-l-lg resize-none bg-grey-50 text-grey-700 ${
-            !userId ? "text-grey-500" : "text-grey-900"
-          } border-none flex-grow min-h-[80px] max-h-[500px]`}
-          disabled={!userId}
-          maxLength={1000}
-        />
-        <button
-          onClick={handleAddComment}
-          className="mr-5 ml-2 px-4 py-4 text-xl font-black bg-primary-100 text-primary-700 rounded-xl border border-primary-200 hover:bg-primary-400"
-          disabled={!userId}
-          style={{ width: "100px" }}
-        >
-          등록
-        </button>
-      </div>
+      <CommentForm
+        comment={comment}
+        userId={userId}
+        onCommentChange={handleCommentChange}
+        onAddComment={handleAddComment}
+      />
     </main>
   );
 };

--- a/src/components/detailpage/DetailPageCommentList.tsx
+++ b/src/components/detailpage/DetailPageCommentList.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import { Comments } from "@/types/Comments.types";
-import { fetchSessionData } from "@/utils/fetchSession";
-import { Session } from "@supabase/supabase-js";
-import { useMutation, useQuery } from "@tanstack/react-query";
-import Image from "next/image";
-import { useState } from "react";
+import { fetchSessionData } from "@/utils/auth";
 import { createClient } from "@/utils/supabase/client";
-import DetailPagePagination from "./DetailPagePagination";
+import { Session } from "@supabase/supabase-js";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import React, { useState } from "react";
+import CommentList from "./commentlist/CommentList";
 
 const supabase = createClient();
 
@@ -19,12 +18,14 @@ interface CommentsResponse {
   comments: Comments[];
   totalCount: number | null;
 }
+
 const ITEMS_PER_PAGE = 4;
 
 const DetailPageCommentList: React.FC<DetailPageCommentListProps> = ({ contentId }) => {
   const [editCommentId, setEditCommentId] = useState<string | null>(null);
   const [newComment, setNewComment] = useState<string>("");
   const [page, setPage] = useState<number>(1);
+  const queryClient = useQueryClient();
 
   const {
     data: sessionData,
@@ -62,8 +63,8 @@ const DetailPageCommentList: React.FC<DetailPageCommentListProps> = ({ contentId
     onSuccess: () => {
       setEditCommentId(null);
       setNewComment("");
-
       alert("댓글 작성이 성공했습니다.");
+      queryClient.invalidateQueries({ queryKey: ["comments", contentId] });
     },
     onError: (error: Error) => {
       console.error("댓글 작성 실패:", error.message);
@@ -75,7 +76,9 @@ const DetailPageCommentList: React.FC<DetailPageCommentListProps> = ({ contentId
     mutationFn: async (commentId: string) => {
       await supabase.from("Comments").delete().eq("comment_id", commentId).single();
     },
-    onSuccess: () => {},
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["comments", contentId] });
+    },
   });
 
   const handleUpdate = async (commentId: string) => {
@@ -114,76 +117,20 @@ const DetailPageCommentList: React.FC<DetailPageCommentListProps> = ({ contentId
   const totalPages = Math.ceil((commentsData?.totalCount || 0) / ITEMS_PER_PAGE);
 
   return (
-    <div className="mt-4 max-w-[1440px] mx-auto">
-      {commentsData?.comments &&
-        commentsData.comments.map((comment: Comments, index) => (
-          <div
-            className="p-4 border border-grey-100 rounded-xl flex flex-col items-start mx-auto mb-4 w-full"
-            key={comment.comment_id ? comment.comment_id : `comment-${index}`}
-          >
-            <div className="flex items-center justify-between w-full">
-              <div className="flex items-center">
-                <Image
-                  src="/assets/images/profile_ex.png"
-                  alt="유저 프로필 사진"
-                  width={45}
-                  height={45}
-                  className="mr-4"
-                />
-                <div>
-                  <h1 className="text-2xl text-grey-700 font-bold py-2">{comment.user_email} 님</h1>
-                  <h2 className="py-2 text-grey-700">{comment.created_at}</h2>
-                </div>
-              </div>
-              {sessionData && sessionData.user.id === comment.user_id && (
-                <div className="flex space-x-2 justify-end">
-                  <button
-                    onClick={() => handleEdit(comment)}
-                    className="px-4 py-2 border-primary-200 font-black bg-primary-100 rounded"
-                  >
-                    수정
-                  </button>
-                  <button
-                    onClick={() => handleDelete(comment.comment_id)}
-                    className="px-4 py-2 bg-white text-primary-600 border border-orange-300 rounded font-black"
-                  >
-                    삭제
-                  </button>
-                </div>
-              )}
-            </div>
-            <div className="mt-2 w-full">
-              {editCommentId === comment.comment_id ? (
-                <div>
-                  <textarea
-                    value={newComment}
-                    onChange={(event) => setNewComment(event.target.value)}
-                    className="w-full p-2 border rounded break-all"
-                    style={{ wordBreak: "break-all" }}
-                  />
-                  <div className="flex justify-end space-x-2 mt-2">
-                    <button
-                      onClick={() => handleUpdate(comment.comment_id)}
-                      className="px-4 py-2 border-primary-200 font-black bg-primary-100 rounded"
-                    >
-                      저장
-                    </button>
-                    <button
-                      onClick={() => setEditCommentId(null)}
-                      className="px-4 py-2 bg-white text-primary-600 border border-orange-300 rounded font-black"
-                    >
-                      취소
-                    </button>
-                  </div>
-                </div>
-              ) : (
-                <p className="py-2 break-all whitespace-pre-wrap pl-14 text-grey-700">{comment.comment}</p>
-              )}
-            </div>
-          </div>
-        ))}
-      <DetailPagePagination totalPages={totalPages} page={page} setPage={setPage} />
-    </div>
+    <CommentList
+      comments={commentsData?.comments || []}
+      totalPages={totalPages}
+      currentPage={page}
+      userId={sessionData?.user?.id || null}
+      editCommentId={editCommentId}
+      newComment={newComment}
+      onEdit={handleEdit}
+      onDelete={handleDelete}
+      onUpdate={handleUpdate}
+      onCancel={() => setEditCommentId(null)}
+      onChange={(event) => setNewComment(event.target.value)}
+      setPage={setPage}
+    />
   );
 };
 

--- a/src/components/detailpage/DetailPageLikeButton.tsx
+++ b/src/components/detailpage/DetailPageLikeButton.tsx
@@ -1,14 +1,10 @@
 "use client";
 
-import { Likes } from "@/types/Likes.types";
-import { createClient } from "@/utils/supabase/client";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import Image from "next/image";
-import React, { useEffect, useState } from "react";
+import React from "react";
+import LikeButton from "./likebutton/LikeButton";
+import { UserSessionProvider } from "./likebutton/UserSessionProvider";
 
-const supabase = createClient();
-
-interface LikeButtonProps {
+interface DetailPageLikeButtonProps {
   contentId: string;
   imageUrl: string;
   contentTypeId: string;
@@ -17,167 +13,25 @@ interface LikeButtonProps {
   tel: string;
 }
 
-interface ContextType {
-  previousLikes: Likes[] | undefined;
-}
-
-const DetailPageLikeButton: React.FC<LikeButtonProps> = ({ contentId, imageUrl, contentTypeId, title, addr1, tel }) => {
-  const [liked, setLiked] = useState<Boolean>(false);
-  const [userId, setUserId] = useState<string | null>(null);
-  const queryClient = useQueryClient();
-
-  useEffect(() => {
-    const fetchSession = async () => {
-      const {
-        data: { session },
-        error,
-      } = await supabase.auth.getSession();
-      if (error) {
-        console.error("Error fetching session:", error);
-      } else if (session) {
-        setUserId(session.user.id);
-        await ensureUserExists(session.user.id);
-      }
-    };
-    fetchSession();
-  }, []);
-
-  const ensureUserExists = async (userId: string) => {
-    const { data: user, error } = await supabase.from("Users").select("id").eq("id", userId).single();
-    if (error && error.code === "PGRST116") {
-      const { error: insertError } = await supabase.from("Users").insert([{ id: userId }]);
-      if (insertError) {
-        console.error("유저정보(소셜로그인 사용자 데이터 like 테이블 입력) 입력실패:", insertError);
-      }
-    } else if (error) {
-      console.error("유저 정보 가져오기 오류", error);
-    }
-  };
-
-  const { isPending, isError, data } = useQuery<Likes[]>({
-    queryKey: ["likes", contentId],
-    queryFn: async () => {
-      const { data: likes, error } = await supabase.from("Likes").select("*").eq("content_id", contentId);
-      if (error) {
-        throw error;
-      }
-      return likes;
-    },
-    enabled: !!userId,
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: async (userId: string) => {
-      const { error } = await supabase.from("Likes").delete().match({ user_id: userId, content_id: contentId });
-      if (error) {
-        throw new Error(error.message);
-      }
-    },
-    onSuccess: () => {
-      alert("좋아요가 취소되었습니다");
-      queryClient.invalidateQueries({ queryKey: ["likes", contentId] });
-    },
-    onError: (error) => {
-      console.error("뮤테이션 에러: 좋아요 취소실패", error);
-    },
-  });
-
-  const addMutation = useMutation<Likes, Error, Partial<Likes>, ContextType>({
-    mutationFn: async (variables) => {
-      if (!userId) {
-        alert("로그인 후 좋아요를 누를 수 있습니다.");
-        throw new Error("세션 정보가 없습니다.");
-      }
-
-      const { data, error } = await supabase
-        .from("Likes")
-        .insert([
-          {
-            user_id: userId,
-            content_id: contentId,
-            image_url: imageUrl,
-            content_type_id: contentTypeId,
-            title: title,
-            address: addr1,
-            tel: tel,
-          },
-        ])
-        .single();
-
-      if (error) {
-        throw new Error(error.message);
-      }
-
-      if (!data) {
-        throw new Error("좋아요 추가에 실패했습니다.");
-      }
-
-      return data as Likes;
-    },
-    onMutate: async (variables) => {
-      await queryClient.cancelQueries({ queryKey: ["likes", contentId] });
-      const previousLikes = queryClient.getQueryData<Likes[]>(["likes", contentId]);
-
-      if (previousLikes) {
-        queryClient.setQueryData<Likes[]>(["likes", contentId], [...previousLikes, variables as Likes]);
-      } else {
-        queryClient.setQueryData<Likes[]>(["likes", contentId], [variables as Likes]);
-      }
-
-      return { previousLikes };
-    },
-
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ["likes", contentId] });
-      alert("좋아요 등록이 성공했습니다.");
-    },
-  });
-
-  useEffect(() => {
-    if (data) {
-      const result = data.find((item) => item.user_id === userId);
-      setLiked(!!result);
-    }
-  }, [data, userId]);
-
-  if (isPending) {
-    return <Image src="/assets/images/defaultLikeIcon.png" alt={"Unlike"} width={70} height={70} />;
-  }
-
-  if (isError) {
-    return <div>에러가 감지되었습니다....</div>;
-  }
-
-  const handleLikeButton = async () => {
-    try {
-      if (liked) {
-        deleteMutation.mutate(userId!);
-      } else {
-        addMutation.mutate({
-          user_id: userId,
-          content_id: contentId,
-          image_url: imageUrl,
-          content_type_id: contentTypeId,
-          title: title,
-          address: addr1,
-          tel: tel,
-        });
-      }
-      setLiked((prevLiked) => !prevLiked);
-    } catch (error) {
-      console.error("좋아요 상태 업데이트를 실패했습니다", error);
-    }
-  };
-
-  const likeImage =
-    data && data.find((item) => item.user_id === userId)
-      ? "/assets/images/successLikeIcon.png"
-      : "/assets/images/defaultLikeIcon.png";
-
+const DetailPageLikeButton: React.FC<DetailPageLikeButtonProps> = ({
+  contentId,
+  imageUrl,
+  contentTypeId,
+  title,
+  addr1,
+  tel,
+}) => {
   return (
-    <button onClick={handleLikeButton} disabled={!userId}>
-      <Image src={likeImage} alt={liked ? "Unlike" : "Like"} width={70} height={70} />
-    </button>
+    <UserSessionProvider>
+      <LikeButton
+        contentId={contentId}
+        imageUrl={imageUrl}
+        contentTypeId={contentTypeId}
+        title={title}
+        addr1={addr1}
+        tel={tel}
+      />
+    </UserSessionProvider>
   );
 };
 

--- a/src/components/detailpage/KakaoMap.tsx
+++ b/src/components/detailpage/KakaoMap.tsx
@@ -29,7 +29,7 @@ const KakaoMap: React.FC<KakaoMapProps> = ({ mapx, mapy }) => {
 
           const map = new window.kakao.maps.Map(mapContainer, mapOption);
 
-          const imageSrc = "/assets/images/detailpageMarker.png";
+          const imageSrc = "/assets/images/marker.svg";
           const imageSize = new window.kakao.maps.Size(64, 69);
           const imageOption = { offset: new window.kakao.maps.Point(27, 69) };
 

--- a/src/components/detailpage/addcomment/CommentForm.tsx
+++ b/src/components/detailpage/addcomment/CommentForm.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import React from "react";
+
+interface CommentFormProps {
+  comment: string;
+  userId: string | null;
+  onCommentChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onAddComment: () => void;
+}
+
+const CommentForm: React.FC<CommentFormProps> = ({ comment, userId, onCommentChange, onAddComment }) => {
+  return (
+    <div className="p-4 border border-primary-100 rounded-xl flex items-center bg-grey-50 py-12">
+      <textarea
+        value={comment}
+        onChange={onCommentChange}
+        placeholder={userId ? "댓글을 작성하세요" : "댓글 작성은 로그인한 유저만 가능합니다"}
+        className={`w-full p-2 rounded-l-lg resize-none bg-grey-50 text-grey-700 ${
+          !userId ? "text-grey-500" : "text-grey-900"
+        } border-none flex-grow min-h-[80px] max-h-[500px]`}
+        disabled={!userId}
+        maxLength={1000}
+      />
+      <button
+        onClick={onAddComment}
+        className="mr-5 ml-2 px-4 py-4 text-xl font-black bg-primary-100 text-primary-700 rounded-xl border border-primary-200 hover:bg-primary-400"
+        disabled={!userId}
+        style={{ width: "100px" }}
+      >
+        등록
+      </button>
+    </div>
+  );
+};
+
+export default CommentForm;

--- a/src/components/detailpage/commentlist/CommentItem.tsx
+++ b/src/components/detailpage/commentlist/CommentItem.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { Comments } from "@/types/Comments.types";
+import Image from "next/image";
+import React from "react";
+
+interface CommentItemProps {
+  comment: Comments;
+  userId: string | null;
+  editCommentId: string | null;
+  newComment: string;
+  onEdit: (comment: Comments) => void;
+  onDelete: (commentId: string) => void;
+  onUpdate: (commentId: string) => void;
+  onCancel: () => void;
+  onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+}
+
+const CommentItem: React.FC<CommentItemProps> = ({
+  comment,
+  userId,
+  editCommentId,
+  newComment,
+  onEdit,
+  onDelete,
+  onUpdate,
+  onCancel,
+  onChange,
+}) => {
+  return (
+    <div className="p-4 border border-grey-100 rounded-xl flex flex-col items-start mx-auto mb-4 w-full">
+      <div className="flex items-center justify-between w-full">
+        <div className="flex items-center">
+          <Image src="/assets/images/profile_ex.png" alt="유저 프로필 사진" width={45} height={45} className="mr-4" />
+          <div>
+            <h1 className="text-2xl text-grey-700 font-bold py-2">{comment.user_email} 님</h1>
+            <h2 className="py-2 text-grey-700">{comment.created_at}</h2>
+          </div>
+        </div>
+        {userId === comment.user_id && (
+          <div className="flex space-x-2 justify-end">
+            <button
+              onClick={() => onEdit(comment)}
+              className="px-4 py-2 border-primary-200 font-black bg-primary-100 rounded"
+            >
+              수정
+            </button>
+            <button
+              onClick={() => onDelete(comment.comment_id)}
+              className="px-4 py-2 bg-white text-primary-600 border border-orange-300 rounded font-black"
+            >
+              삭제
+            </button>
+          </div>
+        )}
+      </div>
+      <div className="mt-2 w-full">
+        {editCommentId === comment.comment_id ? (
+          <div>
+            <textarea
+              value={newComment}
+              onChange={onChange}
+              className="w-full p-2 border rounded break-all"
+              style={{ wordBreak: "break-all" }}
+            />
+            <div className="flex justify-end space-x-2 mt-2">
+              <button
+                onClick={() => onUpdate(comment.comment_id)}
+                className="px-4 py-2 border-primary-200 font-black bg-primary-100 rounded"
+              >
+                저장
+              </button>
+              <button
+                onClick={onCancel}
+                className="px-4 py-2 bg-white text-primary-600 border border-orange-300 rounded font-black"
+              >
+                취소
+              </button>
+            </div>
+          </div>
+        ) : (
+          <p className="py-2 break-all whitespace-pre-wrap pl-14 text-grey-700">{comment.comment}</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default CommentItem;

--- a/src/components/detailpage/commentlist/CommentList.tsx
+++ b/src/components/detailpage/commentlist/CommentList.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Comments } from "@/types/Comments.types";
+import React from "react";
+import DetailPagePagination from "../DetailPagePagination";
+import CommentItem from "./CommentItem";
+
+interface CommentListProps {
+  comments: Comments[];
+  totalPages: number;
+  currentPage: number;
+  userId: string | null;
+  editCommentId: string | null;
+  newComment: string;
+  onEdit: (comment: Comments) => void;
+  onDelete: (commentId: string) => void;
+  onUpdate: (commentId: string) => void;
+  onCancel: () => void;
+  onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  setPage: React.Dispatch<React.SetStateAction<number>>;
+}
+
+const CommentList: React.FC<CommentListProps> = ({
+  comments,
+  totalPages,
+  currentPage,
+  userId,
+  editCommentId,
+  newComment,
+  onEdit,
+  onDelete,
+  onUpdate,
+  onCancel,
+  onChange,
+  setPage,
+}) => {
+  return (
+    <div className="mt-4 max-w-[1440px] mx-auto">
+      {comments.map((comment, index) => (
+        <CommentItem
+          key={comment.comment_id ? comment.comment_id : `comment-${index}`}
+          comment={comment}
+          userId={userId}
+          editCommentId={editCommentId}
+          newComment={newComment}
+          onEdit={onEdit}
+          onDelete={onDelete}
+          onUpdate={onUpdate}
+          onCancel={onCancel}
+          onChange={onChange}
+        />
+      ))}
+      <DetailPagePagination totalPages={totalPages} page={currentPage} setPage={setPage} />
+    </div>
+  );
+};
+
+export default CommentList;

--- a/src/components/detailpage/likebutton/LikeButton.tsx
+++ b/src/components/detailpage/likebutton/LikeButton.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { Likes } from "@/types/Likes.types";
+import { createClient } from "@/utils/supabase/client";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import React, { useEffect, useState } from "react";
+import LikeIcon from "./LikeIcon";
+import { useUserSession } from "./UserSessionProvider";
+
+const supabase = createClient();
+
+interface LikeButtonProps {
+  contentId: string;
+  imageUrl: string;
+  contentTypeId: string;
+  title: string;
+  addr1: string;
+  tel: string;
+}
+
+interface ContextType {
+  previousLikes: Likes[] | undefined;
+}
+
+const LikeButton: React.FC<LikeButtonProps> = ({ contentId, imageUrl, contentTypeId, title, addr1, tel }) => {
+  const [liked, setLiked] = useState<Boolean>(false);
+  const { userId } = useUserSession();
+  const queryClient = useQueryClient();
+
+  const { isLoading, isError, data } = useQuery<Likes[]>({
+    queryKey: ["likes", contentId],
+    queryFn: async () => {
+      const { data: likes, error } = await supabase.from("Likes").select("*").eq("content_id", contentId);
+      if (error) {
+        throw error;
+      }
+      return likes;
+    },
+    enabled: !!userId,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (userId: string) => {
+      const { error } = await supabase.from("Likes").delete().match({ user_id: userId, content_id: contentId });
+      if (error) {
+        throw new Error(error.message);
+      }
+    },
+    onSuccess: () => {
+      alert("좋아요가 취소되었습니다");
+      queryClient.invalidateQueries({ queryKey: ["likes", contentId] });
+    },
+    onError: (error) => {
+      console.error("뮤테이션 에러: 좋아요 취소실패", error);
+    },
+  });
+
+  const addMutation = useMutation<Likes, Error, Partial<Likes>, ContextType>({
+    mutationFn: async (variables) => {
+      if (!userId) {
+        alert("로그인 후 좋아요를 누를 수 있습니다.");
+        throw new Error("세션 정보가 없습니다.");
+      }
+
+      const { data, error } = await supabase
+        .from("Likes")
+        .insert([
+          {
+            user_id: userId,
+            content_id: contentId,
+            image_url: imageUrl,
+            content_type_id: contentTypeId,
+            title: title,
+            address: addr1,
+            tel: tel,
+          },
+        ])
+        .single();
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      if (!data) {
+        throw new Error("좋아요 추가에 실패했습니다.");
+      }
+
+      return data as Likes;
+    },
+    onMutate: async (variables) => {
+      await queryClient.cancelQueries({ queryKey: ["likes", contentId] });
+      const previousLikes = queryClient.getQueryData<Likes[]>(["likes", contentId]);
+
+      if (previousLikes) {
+        queryClient.setQueryData<Likes[]>(["likes", contentId], [...previousLikes, variables as Likes]);
+      } else {
+        queryClient.setQueryData<Likes[]>(["likes", contentId], [variables as Likes]);
+      }
+
+      return { previousLikes };
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["likes", contentId] });
+      alert("좋아요 등록이 성공했습니다.");
+    },
+  });
+
+  useEffect(() => {
+    if (data) {
+      const result = data.find((item) => item.user_id === userId);
+      setLiked(!!result);
+    }
+  }, [data, userId]);
+
+  const handleLikeButton = async () => {
+    try {
+      if (liked) {
+        deleteMutation.mutate(userId!);
+      } else {
+        addMutation.mutate({
+          user_id: userId,
+          content_id: contentId,
+          image_url: imageUrl,
+          content_type_id: contentTypeId,
+          title: title,
+          address: addr1,
+          tel: tel,
+        });
+      }
+      setLiked((prevLiked) => !prevLiked);
+    } catch (error) {
+      console.error("좋아요 상태 업데이트를 실패했습니다", error);
+    }
+  };
+
+  if (isLoading) {
+    return <LikeIcon liked={false} />;
+  }
+
+  if (isError) {
+    return <div>에러가 감지되었습니다....</div>;
+  }
+
+  return (
+    <button onClick={handleLikeButton} disabled={!userId}>
+      <LikeIcon liked={liked} />
+    </button>
+  );
+};
+
+export default LikeButton;

--- a/src/components/detailpage/likebutton/LikeIcon.tsx
+++ b/src/components/detailpage/likebutton/LikeIcon.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import Image from "next/image";
+import React from "react";
+
+interface LikeIconProps {
+  liked: Boolean;
+}
+
+const LikeIcon: React.FC<LikeIconProps> = ({ liked }) => {
+  const likeImage = liked ? "/assets/images/successLikeIcon.png" : "/assets/images/defaultLikeIcon.png";
+  return <Image src={likeImage} alt={liked ? "Unlike" : "Like"} width={70} height={70} />;
+};
+
+export default LikeIcon;

--- a/src/components/detailpage/likebutton/UserSessionProvider.tsx
+++ b/src/components/detailpage/likebutton/UserSessionProvider.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { createClient } from "@/utils/supabase/client";
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+const supabase = createClient();
+
+interface UserSessionContextProps {
+  userId: string | null;
+  ensureUserExists: (userId: string) => Promise<void>;
+}
+
+const UserSessionContext = createContext<UserSessionContextProps | undefined>(undefined);
+
+export const UserSessionProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [userId, setUserId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchSession = async () => {
+      const {
+        data: { session },
+        error,
+      } = await supabase.auth.getSession();
+      if (error) {
+        console.error("Error fetching session:", error);
+      } else if (session) {
+        setUserId(session.user.id);
+        await ensureUserExists(session.user.id);
+      }
+    };
+    fetchSession();
+  }, []);
+
+  const ensureUserExists = async (userId: string) => {
+    const { data: user, error } = await supabase.from("Users").select("id").eq("id", userId).single();
+    if (error && error.code === "PGRST116") {
+      const { error: insertError } = await supabase.from("Users").insert([{ id: userId }]);
+      if (insertError) {
+        console.error("유저정보(소셜로그인 사용자 데이터 like 테이블 입력) 입력실패:", insertError);
+      }
+    } else if (error) {
+      console.error("유저 정보 가져오기 오류", error);
+    }
+  };
+
+  return <UserSessionContext.Provider value={{ userId, ensureUserExists }}>{children}</UserSessionContext.Provider>;
+};
+
+export const useUserSession = (): UserSessionContextProps => {
+  const context = useContext(UserSessionContext);
+  if (!context) {
+    throw new Error("useUserSession must be used within a UserSessionProvider");
+  }
+  return context;
+};

--- a/src/hooks/detailpage/useSessionData.ts
+++ b/src/hooks/detailpage/useSessionData.ts
@@ -1,5 +1,5 @@
-import { fetchSessionData } from "@/utils/fetchSession";
 import { useQuery } from "@tanstack/react-query";
+import { fetchSessionData } from "./../../utils/auth";
 
 export const useSessionData = () => {
   return useQuery({


### PR DESCRIPTION
기존 운성님이 인증인가 관련 변경사항을 기반으로 fetchSession import 경로를 auth로 바꿔서 이제 인증 상태 구분을 제대로 합니다

아직 유저 정보는 nickname말고 email로 이름을 표기하고 있는데 추후 바꿔야 할거 같습니다

invalidateQueries 기능 상실했던 부분을 다시 복구했습니다(수정 삭제시 새로고침없이 바로 반영)

css 수정 반영사항 

overview의 글자가 한줄에 40글자가 넘어가면 다음줄로 넘어가던걸 70으로 바꿨습니다

map maker를 바꿨습니다

댓글 수정 삭제 좋아요 부분을 리팩토링 했는데 이 부분은 gpt로 수행하고 기존 로직과 크게 다르지 않고 작동이 잘되기 때문에 사용해도 될거 같습니다

