### PR TITLE
fix: 디테일페이지

### DIFF
--- a/src/app/(main)/detail/[contentId]/page.tsx
+++ b/src/app/(main)/detail/[contentId]/page.tsx
@@ -12,15 +12,28 @@ import KakaoMap from "@/components/detailpage/KakaoMap";
 import ShareModal from "@/components/detailpage/ShareModal";
 import { useContentId } from "@/hooks/detailpage/useContentId";
 import { useContentItem } from "@/hooks/detailpage/useContentItem";
+import { parseHTMLString } from "@/utils/detailpage/StringUtils";
 import Image from "next/image";
 import { useState } from "react";
-import { parseHTMLString } from "../../../../utils/detailpage/StringUtils";
 
 const DetailPage = () => {
   const contentId = useContentId();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const { data: contentItemData, isPending: pendingContentItem, error: contentItemError } = useContentItem(contentId);
+  const {
+    firstimage: imageUrl,
+    contenttypeid: contentTypeId,
+    title,
+    addr1,
+    tel,
+    homepage,
+    overview,
+    mapx,
+    mapy,
+  } = contentItemData?.data || {};
+
+  const homepageLink = homepage ? parseHTMLString(homepage) : null;
 
   if (pendingContentItem) {
     return <LoadingPage />;
@@ -30,23 +43,21 @@ const DetailPage = () => {
     return <h1>에러가 발생했습니다: {contentItemError.message}</h1>;
   }
 
-  const homepageLink = contentItemData?.data?.homepage ? parseHTMLString(contentItemData.data.homepage) : null;
-
   return (
     <main className="max-w-[1440px] mx-auto grid justify-items-center">
       <DetailPageImage contentItemData={contentItemData} />
       <section className="flex justify-between items-center w-full max-w-[1440px] mt-12 py-20">
         <div className="text-left">
-          <div className="text-4xl font-bold">{contentItemData?.data?.title}</div>
+          <div className="text-4xl font-bold">{title}</div>
         </div>
         <div className="flex justify-center space-x-2">
           <DetailPageLikeButton
             contentId={contentId}
-            imageUrl={contentItemData?.data?.firstimage || ""}
-            title={contentItemData?.data?.title}
-            contentTypeId={contentItemData?.data?.contenttypeid}
-            addr1={contentItemData?.data?.addr1 || ""}
-            tel={contentItemData?.data?.tel || ""}
+            imageUrl={imageUrl || ""}
+            title={title || ""}
+            contentTypeId={contentTypeId || ""}
+            addr1={addr1 || ""}
+            tel={tel || ""}
           />
           <button onClick={() => setIsModalOpen(true)}>
             <Image src="/assets/images/shareModal.svg" alt="Custom Button Image" width={48} height={48} />
@@ -55,22 +66,14 @@ const DetailPage = () => {
         </div>
       </section>
       <section className="w-full max-w-[1440px] mt-4">
-        <ContentDetail
-          title={contentItemData?.data?.title || ""}
-          addr1={contentItemData?.data?.addr1 || ""}
-          tel={contentItemData?.data?.tel || ""}
-          homepageLink={homepageLink}
-        />
+        <ContentDetail title={title || ""} addr1={addr1 || ""} tel={tel || ""} homepageLink={homepageLink} />
       </section>
-      {contentItemData?.data?.overview && <ContentOverview overview={contentItemData.data.overview} />}
+      {contentItemData?.data?.overview && <ContentOverview overview={overview || ""} />}
       <section className="w-full [1440px] flex justify-center mb-15">
-        <KakaoMap
-          mapx={parseFloat(contentItemData?.data?.mapx || "0")}
-          mapy={parseFloat(contentItemData?.data?.mapy || "0")}
-        />
+        <KakaoMap mapx={parseFloat(mapx || "0")} mapy={parseFloat(mapy || "0")} />
       </section>
       <section className="w-full max-w-[1440px] mt-20 pt-20">
-        <DetailPageAddComment contentId={contentId} contenTypeId={contentItemData?.data?.contenttypeid} />
+        <DetailPageAddComment contentId={contentId} contenTypeId={contentTypeId || ""} />
         <DetailPageCommentList contentId={contentId} />
       </section>
       <FloatingButton />


### PR DESCRIPTION
피드백 받은 내용을 기준으로 디테일 페이지에서 useContentItem 훅을 이용해서 내려받는 데이터를
구조분해 할당으로 재정립 후 유지보수및 가독성을 높였습니다.