### PR TITLE
fix: api 파람스 변경

### DIFF
--- a/src/app/api/detail/[contentId]/route.ts
+++ b/src/app/api/detail/[contentId]/route.ts
@@ -14,7 +14,7 @@ export const GET = async (request: NextRequest, { params }: { params: { contentI
         numOfRows: 1,
         pageNo: 1,
         MobileOS: "ETC",
-        MobileApp: "AppTest",
+        MobileApp: "horang",
         contentId: contentId,
         firstImageYN: "Y",
         areacodeYN: "Y",

--- a/src/app/api/main/tourism/festival/route.ts
+++ b/src/app/api/main/tourism/festival/route.ts
@@ -1,5 +1,5 @@
-import axios from "axios";
 import { ApiInformation } from "@/types/Main";
+import axios from "axios";
 import { NextResponse } from "next/server";
 
 export async function GET(): Promise<Response> {
@@ -13,7 +13,7 @@ export async function GET(): Promise<Response> {
         numOfRows: 1000,
         pageNo: 1,
         MobileOS: "ETC",
-        MobileApp: "TestApp",
+        MobileApp: "horang",
         _type: "json",
         listYN: "Y",
         arrange: "A",

--- a/src/app/api/main/tourism/leports/route.ts
+++ b/src/app/api/main/tourism/leports/route.ts
@@ -1,5 +1,5 @@
-import axios from "axios";
 import { ApiInformation } from "@/types/Main";
+import axios from "axios";
 import { NextResponse } from "next/server";
 
 export async function GET(): Promise<Response> {
@@ -13,7 +13,7 @@ export async function GET(): Promise<Response> {
         numOfRows: 1000,
         pageNo: 1,
         MobileOS: "ETC",
-        MobileApp: "TestApp",
+        MobileApp: "horang",
         _type: "json",
         listYN: "Y",
         arrange: "A",

--- a/src/app/api/main/tourism/route.ts
+++ b/src/app/api/main/tourism/route.ts
@@ -1,5 +1,5 @@
-import axios from "axios";
 import { ApiInformation } from "@/types/Main";
+import axios from "axios";
 import { NextResponse } from "next/server";
 
 export async function GET(request: Request) {
@@ -15,7 +15,7 @@ export async function GET(request: Request) {
         numOfRows: 1000,
         pageNo: 1,
         MobileOS: "ETC",
-        MobileApp: "TestApp",
+        MobileApp: "horang",
         _type: "json",
         listYN: "Y",
         arrange: "A",

--- a/src/app/api/main/tourism/travel/route.ts
+++ b/src/app/api/main/tourism/travel/route.ts
@@ -1,5 +1,5 @@
-import axios from "axios";
 import { ApiInformation } from "@/types/Main";
+import axios from "axios";
 import { NextResponse } from "next/server";
 
 export async function GET(): Promise<Response> {
@@ -13,7 +13,7 @@ export async function GET(): Promise<Response> {
         numOfRows: 1000,
         pageNo: 1,
         MobileOS: "ETC",
-        MobileApp: "TestApp",
+        MobileApp: "horang",
         _type: "json",
         listYN: "Y",
         arrange: "A",

--- a/src/hooks/useTouristSpots.ts
+++ b/src/hooks/useTouristSpots.ts
@@ -29,7 +29,7 @@ const fetchTouristSpots = async (latitude: number, longitude: number): Promise<T
       numOfRows: 1000,
       pageNo: 1,
       MobileOS: "ETC",
-      MobileApp: "AppTest",
+      MobileApp: "horang",
       _type: "json",
       mapX: longitude,
       mapY: latitude,


### PR DESCRIPTION
웹서비스 신청을 위한 파람스 신청 값 변경

예시)

   params: {
        serviceKey: process.env.NEXT_PUBLIC_TOURIST_API_KEY,
        numOfRows: 1,
        pageNo: 1,
        MobileOS: "ETC",
        MobileApp: "horang",            ---> 기존 TestApp or apptest 였던 부분을 horang으로 변경
        contentId: contentId,
        firstImageYN: "Y",
        areacodeYN: "Y",
        catcodeYN: "Y",
        addrinfoYN: "Y",
        mapinfoYN: "Y",
        overviewYN: "Y",
        defaultYN: "Y",
        _type: "json",
      },


호출과 기능에는 아무런 이상이 없습니다.