### PR TITLE
Feat#80 디테일페이지 반응형 css 수정 외

### DIFF
--- a/src/app/(main)/detail/[contentId]/page.tsx
+++ b/src/app/(main)/detail/[contentId]/page.tsx
@@ -44,12 +44,10 @@ const DetailPage = () => {
   }
 
   return (
-    <main className="sm:max-w-[640px] md:max-w-[1024px] md:mx-auto md:grid md:justify-items-center lg:max-w-[1440px] lg:mx-auto lg:grid lg:justify-items-center">
+    <main className="sm:w-full sm:max-w-full sm:mx-auto md:max-w-[1024px] md:mx-auto md:grid md:justify-items-center lg:max-w-[1440px] lg:mx-auto lg:grid lg:justify-items-center">
       <DetailPageImage contentItemData={contentItemData} />
-      <section
-        className="flex justify-between items-center w-full max-w-[1440px] lg:pt-[140px] md:flex md:items-center md:justify-between md:w-full md:max-w-[1024px] md:mt-8
-      sm:px-[24px] sm:pt-[46px] sm:pb-[17px]"
-      >
+
+      <section className="flex justify-between items-center w-full max-w-[1440px] lg:pt-[140px] md:flex md:items-center md:justify-between md:w-full md:max-w-[1024px] md:mt-8 md:px-[32px] sm:px-[24px] sm:pt-[46px] sm:pb-[17px]">
         <div className="text-left md:flex-grow">
           <div className="lg:text-[38px] lg:font-bold md:text-[30px] md:font-semibold sm:text-[14px] sm:font-bold">
             {title}
@@ -76,21 +74,36 @@ const DetailPage = () => {
           <ShareModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} />
         </div>
       </section>
-      <section className="md:w-full md:max-w-[1024px] md:mt-4 lg:w-full lg:max-w-[1440px] lg:mt-4 lg:pb-[88px] sm:w-[640px] sm:px-[24px] sm:">
-        <ContentDetail title={title || ""} addr1={addr1 || ""} tel={tel || ""} homepageLink={homepageLink} />
+
+      <section className="md:w-full md:max-w-[1024px] md:mt-4 md:px-[24px] lg:w-full lg:max-w-[1440px] lg:mt-4 lg:pb-[88px] sm:w-full sm:px-[24px]">
+        <ContentDetail
+          title={title || ""}
+          addr1={addr1 || ""}
+          tel={tel || ""}
+          homepageLink={homepageLink}
+          contenttypeid={contentTypeId || ""}
+        />
       </section>
-      {contentItemData.data.overview && <ContentOverview overview={overview || ""} />}
-      <section className="md:w-full md:flex md:justify-center md:mb-12 lg:w-full lg:flex lg:justify-center lg:mb-15 sm:max-w-[640px] sm-max-h-[290px]">
+
+      {contentItemData.data.overview && (
+        <div className="md:px-[32px]">
+          <ContentOverview overview={overview || ""} />
+        </div>
+      )}
+
+      <section className="md:w-full md:flex md:justify-center md:mb-12 lg:w-full lg:flex lg:justify-center lg:mb-15 sm:max-w-full sm-max-h-[290px]">
         <KakaoMap mapx={parseFloat(mapx || "0")} mapy={parseFloat(mapy || "0")} />
       </section>
-      <section className="md:w-full md:max-w-[1024px] md:mt-12 md:pt-12 lg:w-full lg:max-w-[1440px] lg:mt-20 lg:pt-[200px] sm:max-w-[640px]">
+
+      <section className="md:w-full md:max-w-[1024px] md:mt-12 md:pt-12 md:px-[24px] lg:w-full lg:max-w-[1440px] lg:mt-20 lg:pt-[200px] sm:max-w-full">
         <div className="lg:pt-[16px] md:pt-[16px]">
-          <DetailPageAddComment contentId={contentId} contenTypeId={contentTypeId || ""} />
+          <DetailPageAddComment contentId={contentId} contentTypeId={contentTypeId || ""} />
         </div>
         <div className="lg:pt-[16px] md:pt-[16px]">
           <DetailPageCommentList contentId={contentId} />
         </div>
       </section>
+
       <FloatingButton />
     </main>
   );

--- a/src/components/detailpage/ContentDetail.tsx
+++ b/src/components/detailpage/ContentDetail.tsx
@@ -5,73 +5,95 @@ interface ContentDetailProps {
   addr1: string | null;
   tel: string | null;
   homepageLink: string | null;
+  contenttypeid: string | null;
 }
 
-const ContentDetail: React.FC<ContentDetailProps> = ({ title, addr1, tel, homepageLink }) => {
+const ContentDetail: React.FC<ContentDetailProps> = ({ title, addr1, tel, homepageLink, contenttypeid }) => {
   const truncateText = (text: string, maxLength: number) => {
     if (text.length <= maxLength) return text;
     return text.substring(0, maxLength) + "...";
   };
 
+  const getContentTypeName = (id: string | null) => {
+    switch (id) {
+      case "12":
+        return "관광지";
+      case "14":
+        return "문화시설";
+      case "15":
+        return "축제/공연/행사";
+      case "25":
+        return "여행코스";
+      case "28":
+        return "레포츠";
+      case "32":
+        return "숙박";
+      case "38":
+        return "쇼핑";
+      case "39":
+        return "음식";
+      default:
+        return "기타";
+    }
+  };
+
   return (
-    <div className="md:text-left md:text-grey-700 lg:text-left lg:text-grey-700 sm:text-left">
-      {title && (
-        <div className="md:flex md:items-center md:py-2 lg:flex lg:items-center lg:py-3 sm:flex sm:mb-[10px]">
+    <div className="text-left text-grey-700 ">
+      {contenttypeid && (
+        <div className="flex items-center py-3 sm:mb-2">
           <Image
             src="/assets/images/detailpage/marker_title.svg"
-            alt="장소명"
+            alt="컨텐츠타입"
             width={32}
             height={32}
-            className="sm:w-[20px] sm:h-[20px]"
+            className="sm:w-5 sm:h-5"
           />
-          <span className="md:text-[20px] md:font-normal md:ml-8 lg:text-[28px] lg:font-normal lg:ml-12 sm:text-grey-600 sm:font-normal sm:text-[12px] sm:pl-2">
-            {title}
+          <span className="ml-4 sm:text-[12px] sm:ml-2 md:text-lg lg:text-xl font-normal text-grey-600">
+            {getContentTypeName(contenttypeid)}
           </span>
         </div>
       )}
 
       {addr1 && (
-        <div className="md:flex md:items-center md:py-2 lg:flex lg:items-center lg:py-3 sm:flex sm:mb-[10px]">
+        <div className="flex items-center py-3 sm:mb-2">
           <Image
             src="/assets/images/detailpage/marker_address.svg"
             alt="주소"
             width={32}
             height={32}
-            className="sm:w-[20px] sm:h-[20px]"
+            className="sm:w-5 sm:h-5"
           />
-          <span className="md:text-[20px] md:font-normal md:ml-8 lg:text-[28px] lg:font-normal lg:ml-12 sm:text-[12px] sm:text-grey-600 sm:font-normal sm:pl-2">
-            {addr1}
-          </span>
+          <span className="ml-4 sm:text-[12px] sm:ml-2 md:text-lg lg:text-xl font-normal text-grey-600">{addr1}</span>
         </div>
       )}
+
       {tel && (
-        <div className="md:flex md:items-center md:py-2 lg:flex lg:items-center lg:py-3 sm:flex sm:mb-[10px]">
+        <div className="flex items-center py-3 sm:mb-2">
           <Image
             src="/assets/images/detailpage/marker_tel.svg"
-            alt="tel"
+            alt="전화번호"
             width={32}
             height={32}
-            className="sm:w-[20px] sm:h-[20px]"
+            className="sm:w-5 sm:h-5"
           />
-          <span className="md:text-[20px] md:font-normal md:ml-8 lg:text-[28px] lg:font-normal lg:ml-12 sm:text-[12px] sm:text-grey-600 sm:font-normal sm:pl-2">
-            {tel}
-          </span>
+          <span className="ml-4 sm:text-[12px] sm:ml-2 md:text-lg lg:text-xl font-normal text-grey-600">{tel}</span>
         </div>
       )}
+
       {homepageLink && (
-        <div className="md:flex md:items-center md:py-2 lg:flex lg:items-center lg:py-3 sm:flex sm:mb-[10px]">
+        <div className="flex items-center py-3 sm:mb-2">
           <Image
             src="/assets/images/detailpage/marker_homepage.svg"
-            alt="homepage"
+            alt="홈페이지"
             width={32}
             height={32}
-            className="sm:w-[20px] sm:h-[20px]"
+            className="sm:w-5 sm:h-5"
           />
           <a
             href={homepageLink}
             target="_blank"
             rel="noopener noreferrer"
-            className="md:text-blue-500 md:underline md:text-[20px] lg:text-blue-500 lg:underline md:ml-8 lg:ml-12 lg:text-[28px] sm:text-[12px] sm:text-grey-600 sm:font-normal sm:pl-2"
+            className="ml-4 sm:text-[12px] sm:ml-2 md:text-lg lg:text-xl font-normal text-blue-500 underline"
           >
             <span className="sm:hidden md:inline lg:inline">{homepageLink}</span>
             <span className="sm:inline md:hidden lg:hidden">{truncateText(homepageLink, 50)}</span>

--- a/src/components/detailpage/ContentOverview.tsx
+++ b/src/components/detailpage/ContentOverview.tsx
@@ -13,12 +13,14 @@ const ContentOverview: React.FC<ContentOverviewProps> = ({ overview }) => {
   return (
     <section className="w-full max-w-[1440px] mt-4 text-left py-12 md:w-full md:max-w-[1024px] md:mt-4 md:text-left md:py-8 lg:w-full lg:max-w-[1440px] lg:mt-4 lg:text-left lg:py-12 sm:px-[24px] sm:mt-[-30px]">
       <div className="text-start md:text-start">
-        <h1 className="text-3xl font-bold py-12 md:text-[30px] md:font-bold lg:text-[38px] lg:font-bold lg:pb-[65px] sm:text-[14px] sm:mb-[-30px]">
-          Overview
+        <h1 className="text-3xl font-bold py-12 md:text-[30px] md:font-bold lg:text-[38px] lg:font-bold lg:pb-[65px] sm:text-[14px] sm:mb-[-30px] sm:font-bold sm:leading-[24px]">
+          개요
         </h1>
         <div className="text-grey-700" style={{ whiteSpace: "pre-wrap" }}>
           {showMore ? (
-            <p className="sm:leading-[18px] sm:tracking-[-0.3px]">{overview}</p>
+            <p className="sm:leading-[24px] sm:tracking-[-0.3px] sm:text-[12px] sm:font-normal sm:grey-600">
+              {overview}
+            </p>
           ) : (
             <p>{overview.substring(0, 500)}...</p>
           )}

--- a/src/components/detailpage/DetailPageAddComment.tsx
+++ b/src/components/detailpage/DetailPageAddComment.tsx
@@ -11,10 +11,10 @@ const supabase = createClient();
 
 interface DetailPageAddCommentProps {
   contentId: string;
-  contenTypeId: string;
+  contentTypeId: string;
 }
 
-const DetailPageAddComment: React.FC<DetailPageAddCommentProps> = ({ contentId, contenTypeId }) => {
+const DetailPageAddComment: React.FC<DetailPageAddCommentProps> = ({ contentId, contentTypeId }) => {
   const [comment, setComment] = useState<string>("");
   const queryClient = useQueryClient();
   const { id: userId, user_email: userEmail, user_nickname: userNickname, profile_url: profileUrl } = useUserStore();
@@ -31,7 +31,7 @@ const DetailPageAddComment: React.FC<DetailPageAddCommentProps> = ({ contentId, 
           user_id: userId,
           content_id: contentId,
           comment,
-          content_type_id: contenTypeId,
+          content_type_id: contentTypeId,
           user_email: userEmail,
           user_nickname: userNickname,
           user_profile_url: profileUrl,
@@ -72,10 +72,7 @@ const DetailPageAddComment: React.FC<DetailPageAddCommentProps> = ({ contentId, 
   };
 
   return (
-    <main
-      className="sm:mt-[140px] sm:max-w-[375px] sm:mx-auto md:mt-4 md:max-w-[1024px] md:mx-auto lg:mt-4
-     lg:max-w-[1440px] lg:mx-auto"
-    >
+    <main className="sm:mt-[140px] sm:max-w-[375px] sm:mx-auto md:mt-4 md:max-w-[1024px] md:mx-auto lg:mt-4 lg:max-w-[1440px] lg:mx-auto">
       {userId && (
         <div className="sm:pl-[22px] sm:flex sm:items-center sm:py-3 md:flex md:items-center md:mb-4 md:py-3 lg:flex lg:items-center lg:mb-4 lg:py-3">
           {profileUrl && (
@@ -86,7 +83,7 @@ const DetailPageAddComment: React.FC<DetailPageAddCommentProps> = ({ contentId, 
           </span>
         </div>
       )}
-      <div className="sm:p-3 sm:border-none sm:h-[102px] sm:border sm:border-primary-100 sm:rounded-lg sm:flex sm:items-center sm:bg-grey-50 sm:h-[150px] sm:place-items-center md:p-4 md:border md:border-primary-100 md:rounded-xl md:flex md:items-center md:bg-grey-50 md:h-[200px] md:place-items-center lg:p-4 lg:border lg:border-primary-100 lg:rounded-xl lg:flex lg:items-center lg:bg-grey-50 lg:h-[226px] lg:place-items-center">
+      <div className="sm:p-3 sm:border-none sm:h-[102px] md:p-4 md:border md:border-primary-100 md:rounded-xl md:h-[200px] lg:p-4 lg:border lg:border-primary-100 lg:rounded-xl lg:h-[226px] bg-grey-50 flex items-center place-items-center">
         <textarea
           value={comment}
           onChange={(event) => setComment(event.target.value)}
@@ -99,7 +96,7 @@ const DetailPageAddComment: React.FC<DetailPageAddCommentProps> = ({ contentId, 
               ? "댓글을 작성하세요"
               : "댓글 작성은 로그인한 유저만 가능합니다"
           }
-          className={`resize-none sm:pt-[25px] sm:mb-[70px] sm:pb-[5px] sm:w-[270px] sm:p-4 sm:flex-shrink-0 sm:rounded-[20px] sm:bg-grey-100 sm:text-base sm:leading-5 sm:text-grey-600 sm:pl-[24px] sm:text-[12px] sm:mt-[70px] sm:ml-[12px] ${
+          className={`resize-none sm:w-[270px] sm:p-4 sm:flex-shrink-0 sm:rounded-[20px] sm:bg-grey-100 sm:text-[14px] sm:leading-5 sm:text-grey-600 sm:pl-[24px] ${
             !userId ? "text-grey-500" : "text-grey-900"
           } sm:border-none sm:min-h-[24px] sm:resize-y md:max-w-[800px] md:p-4 md:rounded-l-lg md:bg-grey-50 md:h-[150px] md:flex md:flex-col md:text-lg md:leading-6 md:text-grey-600 ${
             !userId ? "text-grey-500" : "text-grey-900"
@@ -111,7 +108,7 @@ const DetailPageAddComment: React.FC<DetailPageAddCommentProps> = ({ contentId, 
         />
         <button
           onClick={handleAddComment}
-          className={`sm:ml-3 sm:p-4 sm-font-[12px] sm:font-normal sm:text-white sm:p-3 sm:flex sm:w-auto sm:h-[24px] sm:flex-col sm:justify-center sm:items-center sm:gap-[24px] sm:text-base sm:font-black sm:bg-primary-400 sm:text-primary-700 sm:rounded-[20px] sm:border-2 sm:border-primary-400 sm:hover:bg-primary-400 sm:px-[10px] sm:ml-[12px] md:ml-4 md:flex md:w-[100px] md:h-[60px] md:flex-col md:justify-center md:items-center md:gap-2 md:text-lg md:font-black md:bg-primary-100 md:text-primary-700 md:rounded-xl md:border-2 md:border-primary-200 md:hover:bg-primary-400 lg:ml-8 lg:flex lg:w-[150px] lg:h-[80px] lg:flex-col lg:justify-center lg:items-center lg:gap-[10px] lg:text-[30px] lg:font-black lg:bg-primary-100 lg:text-primary-700 lg:rounded-[20px] lg:border-2 lg:border-primary-200 lg:hover:bg-primary-400`}
+          className={`sm:ml-3 sm:py-[10px] sm:px-[20px] sm:text-[12px] sm:font-bold sm:text-white sm:bg-primary-400 sm:rounded-2xl md:ml-4 md:w-[100px] md:h-[60px] md:flex md:justify-center md:items-center md:text-lg md:font-black md:bg-primary-100 md:text-primary-700 md:rounded-xl md:border-2 md:border-primary-200 md:hover:bg-primary-400 lg:ml-8 lg:w-[150px] lg:h-[80px] lg:flex lg:justify-center lg:items-center lg:text-[30px] lg:font-black lg:bg-primary-100 lg:text-primary-700 lg:rounded-[20px] lg:border-2 lg:border-primary-200 lg:hover:bg-primary-400`}
           disabled={!userId}
         >
           등록

--- a/src/components/detailpage/DetailPageCommentList.tsx
+++ b/src/components/detailpage/DetailPageCommentList.tsx
@@ -202,7 +202,9 @@ const DetailPageCommentList: React.FC<DetailPageCommentListProps> = ({ contentId
       {commentsData?.comments &&
         commentsData.comments.map((comment: Comments, index) => (
           <div
-            className="sm:p-3 sm:border-none sm:border-grey-100 sm:rounded-lg sm:flex sm:flex-col sm:items-start sm:mx-auto sm:mb-[1px] sm:w-full md:p-4 md:border md:border-grey-100 md:rounded-xl md:flex md:flex-col md:items-start md:mx-auto md:mb-[32px] md:w-full lg:p-4 lg:border lg:border-grey-100 lg:rounded-xl lg:flex lg:flex-col lg:items-start lg:mx-auto lg:mb-[32px] lg:w-full"
+            className={`sm:p-3 sm:rounded-lg sm:flex sm:flex-col sm:items-start sm:mx-auto sm:mb-[1px] sm:w-full md:p-4 md:border md:border-grey-100 md:rounded-xl md:flex md:flex-col md:items-start md:mx-auto md:mb-[32px] md:w-full lg:p-4 lg:border lg:border-grey-100 lg:rounded-xl lg:flex lg:flex-col lg:items-start lg:mx-auto lg:mb-[32px] lg:w-full ${
+              !comment.comment_id ? "sm:border-none" : ""
+            }`}
             key={comment.comment_id ? comment.comment_id : `comment-${index}`}
           >
             <div className="sm:flex sm:items-center sm:justify-between sm:w-full sm:py-3 md:flex md:items-center md:justify-between md:w-full md:py-5 lg:flex lg:items-center lg:justify-between lg:w-full lg:py-5">
@@ -227,7 +229,7 @@ const DetailPageCommentList: React.FC<DetailPageCommentListProps> = ({ contentId
                 <div className="sm:flex sm:space-x-2 sm:justify-end md:flex md:space-x-2 md:justify-end md:pr-[95px] lg:flex lg:space-x-2 lg:justify-end lg:pr-[95px]">
                   <button
                     onClick={() => handleEdit(comment)}
-                    className="sm:flex sm:justify-center sm:items-center sm:h-[30px] sm:py-0 sm:px-[16px] sm:text-[14px] sm:text-grey-600 sm:font-normal sm:rounded md:flex md:justify-center md:items-center md:h-[36px] md:pb-7 md:py-0 md:px-[26px] md:text-[16px] md:text-grey-600 md:font-normal md:rounded lg:flex lg:pb-7 lg:justify-center lg:items-center lg:h-[36px] lg:py-0 lg:px-[26px] lg:text-[18px] lg:text-grey-600 lg:font-normal lg:rounded"
+                    className="sm:flex sm:justify-center sm:items-center sm:h-[30px] sm:py-0 sm:px-[16px] md:flex md:justify-center md:items-center md:h-[36px] md:py-0  lg:flex lg:justify-center lg:items-center lg:h-[36px] lg:py-0 lg:px-[26px]"
                   >
                     <Image
                       src="/assets/images/detailpage/Mode_edit.svg"
@@ -236,11 +238,11 @@ const DetailPageCommentList: React.FC<DetailPageCommentListProps> = ({ contentId
                       height={16}
                       className="sm:block md:hidden lg:hidden"
                     />
-                    <span className="sm:hidden">수정</span>
+                    <span className="hidden md:inline lg:inline">수정</span>
                   </button>
                   <button
                     onClick={() => handleDelete(comment.comment_id)}
-                    className="sm:flex sm:justify-center sm:items-center sm:h-[30px] sm:py-0 sm:px-[16px] sm:text-[14px] sm:text-grey-600 sm:font-normal sm:rounded md:flex md:justify-center md:items-center md:h-[36px] md:pb-7 md:py-0 md:px-[26px] md:rounded md:text-[16px] md:text-grey-600 md:font-normal lg:flex lg:pb-7 lg:justify-center lg:items-center lg:h-[36px] lg:py-0 lg:px-[26px] lg:rounded lg:text-[18px] lg:text-grey-600 lg:font-normal"
+                    className="sm:flex sm:justify-center sm:items-center sm:h-[30px] sm:py-0 sm:px-[16px] md:flex md:justify-center md:items-center md:h-[36px] md:py-0 md:ps-[36px] lg:flex lg:justify-center lg:items-center lg:h-[36px] lg:py-0 lg:px-[26px]"
                   >
                     <Image
                       src="/assets/images/detailpage/Delete.svg"
@@ -249,7 +251,7 @@ const DetailPageCommentList: React.FC<DetailPageCommentListProps> = ({ contentId
                       height={16}
                       className="sm:block md:hidden lg:hidden"
                     />
-                    <span className="sm:hidden">삭제</span>
+                    <span className="hidden md:inline lg:inline">삭제</span>
                   </button>
                 </div>
               )}
@@ -260,26 +262,26 @@ const DetailPageCommentList: React.FC<DetailPageCommentListProps> = ({ contentId
                   <textarea
                     value={newComment}
                     onChange={(event) => setNewComment(event.target.value)}
-                    className="resize-none sm:w-full sm:p-2 sm:border sm:rounded-[20px] sm:bg-grey-100 sm:break-all sm:text-[12px] sm:max-w-[280px] sm:text-grey-600 md:w-full md:ml-[-32px] md:p-2 md:border md:rounded md:break-all md:text-[24px] md:max-w-[800px] md:text-grey-700 lg:w-full lg:p-2 lg:border lg:rounded lg:break-all lg:text-[28px] lg:max-w-[1200px] lg:text-grey-700 lg:ml-[-32px]"
+                    className="resize-none sm:w-full sm:p-2 sm:rounded-[20px] sm:bg-grey-100 sm:break-all sm:text-[12px] sm:max-w-[280px] md:w-full md:ml-[-32px] md:p-2 md:border md:rounded lg:w-full lg:p-2 lg:border lg:rounded lg:break-all lg:text-[28px] lg:max-w-[1200px]"
                     style={{ wordBreak: "break-all" }}
                   />
                   <div className="sm:flex sm:justify-end sm:space-x-2 sm:mt-2 sm:pr-[20px] md:flex md:justify-end md:space-x-2 md:mt-2 md:pr-[95px] lg:flex lg:justify-end lg:space-x-2 lg:mt-2 lg:pr-[95px]">
                     <button
                       onClick={() => handleUpdate(comment.comment_id)}
-                      className="sm:flex sm:justify-center sm:items-center sm:h-[30px] sm:py-0 sm:px-[16px] sm:text-[14px] sm:text-grey-600 sm:font-normal sm:rounded md:flex md:justify-center md:items-center md:h-[36px] md:py-0 md:px-[26px] md:text-[16px] md:text-grey-600 md:font-normal md:rounded lg:flex lg:justify-center lg:items-center lg:h-[36px] lg:py-0 lg:px-[26px] lg:text-[18px] lg:text-grey-600 lg:font-normal lg:rounded"
+                      className="sm:flex sm:justify-center sm:items-center sm:h-[30px] sm:py-0 sm:px-[16px] md:flex md:justify-center md:items-center md:h-[36px] md:py-0 lg:flex lg:justify-center lg:items-center lg:h-[36px] lg:py-0 lg:px-[26px]"
                     >
                       저장
                     </button>
                     <button
                       onClick={handleCancelEdit}
-                      className="sm:flex sm:justify-center sm:items-center sm:h-[30px] sm:py-0 sm:px-[16px] sm:text-[14px] sm:text-grey-600 sm:font-normal sm:rounded md:flex md:justify-center md:items-center md:h-[36px] md:py-0 md:px-[26px] md:text-[16px] md:text-grey-600 md:font-normal md:rounded lg:flex lg:justify-center lg:items-center lg:h-[36px] lg:py-0 lg:px-[26px] lg:text-[18px] lg:text-grey-600 lg:font-normal lg:rounded"
+                      className="sm:flex sm:justify-center sm:items-center sm:h-[30px] sm:py-0 sm:px-[16px] md:flex md:justify-center md:items-center md:h-[36px] md:py-0 md:ps-[36px] lg:flex lg:justify-center lg:items-center lg:h-[36px] lg:py-0 lg:px-[26px]"
                     >
                       취소
                     </button>
                   </div>
                 </div>
               ) : (
-                <p className="sm:ps-[65px] sm:mb-2 sm:pb-2 sm:break-all sm:whitespace-pre-wrap sm:pr-[20px] sm:text-grey-600 sm:text-[12px] md:ps-[105px] md:mb-8 md:pb-5 md:break-all md:whitespace-pre-wrap md:pr-[70px] md:text-grey-700 md:text-[24px] lg:ps-[105px] lg:mb-8 lg:pb-5 lg:break-all lg:whitespace-pre-wrap lg:pr-[95px] lg:text-grey-700 lg:text-[28px]">
+                <p className="sm:ps-[65px] sm:mb-2 sm:pb-2 sm:break-all sm:whitespace-pre-wrap sm:pr-[20px] md:ps-[105px] md:mb-8 md:pb-5 md:break-all md:whitespace-pre-wrap md:pr-[70px] lg:ps-[105px] lg:mb-8 lg:pb-5 lg:break-all lg:whitespace-pre-wrap lg:pr-[95px] lg:text-grey-700 lg:text-[28px]">
                   {comment.comment}
                 </p>
               )}

--- a/src/components/detailpage/DetailPagePagination.tsx
+++ b/src/components/detailpage/DetailPagePagination.tsx
@@ -5,9 +5,12 @@ const DetailPagePagination: React.FC<{
 }> = ({ totalPages, page, setPage }) => {
   return (
     <div style={{ display: "flex", justifyContent: "center", marginTop: "20px" }}>
-      <button onClick={() => setPage((prev) => Math.max(prev - 1, 1))} disabled={page === 1}>
-        prev
-      </button>
+      {totalPages > 1 && (
+        <button onClick={() => setPage((prev) => Math.max(prev - 1, 1))} disabled={page === 1}>
+          prev
+        </button>
+      )}
+
       {[...Array(totalPages)].map((_, index) => (
         <button
           key={index + 1}
@@ -20,9 +23,11 @@ const DetailPagePagination: React.FC<{
           {index + 1}
         </button>
       ))}
-      <button onClick={() => setPage((prev) => Math.min(prev + 1, totalPages))} disabled={page === totalPages}>
-        next
-      </button>
+      {totalPages > 1 && (
+        <button onClick={() => setPage((prev) => Math.min(prev + 1, totalPages))} disabled={page === totalPages}>
+          next
+        </button>
+      )}
     </div>
   );
 };

--- a/src/components/detailpage/DetailPageSwiper.tsx
+++ b/src/components/detailpage/DetailPageSwiper.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 
 const DetailPageImage: React.FC<{ contentItemData: ContentItem }> = ({ contentItemData }) => {
   return (
-    <section className="sm:max-w-[375px] md:w-full md:max-w-[1024px] md:mx-auto lg:w-full lg:max-w-[1440px] lg:mx-auto">
+    <section className="sm:w-full sm:max-w-[375px] sm:mx-auto md:w-full md:max-w-[1024px] md:mx-auto lg:w-full lg:max-w-[1440px] lg:mx-auto">
       {contentItemData.data.firstimage && (
         <Image
           src={contentItemData.data.firstimage || "/assets/images/null_image.svg"}
@@ -12,7 +12,7 @@ const DetailPageImage: React.FC<{ contentItemData: ContentItem }> = ({ contentIt
           width={1440}
           height={350}
           priority
-          className="sm:w-[375px] sm:h-[528px] md:w-full md:h-auto lg:w-full lg:h-auto"
+          className="w-full h-auto mx-auto"
           sizes="(max-width: 640px) 375px, 1440px"
         />
       )}

--- a/src/components/detailpage/KakaoMap.tsx
+++ b/src/components/detailpage/KakaoMap.tsx
@@ -66,11 +66,11 @@ const KakaoMap: React.FC<KakaoMapProps> = ({ mapx, mapy }) => {
   }, [longitude, latitude]);
 
   return (
-    <div className="w-full h-[500px] relative md:w-full md:h-[400px] lg:w-full lg:h-[500px] sm:w-[375px]">
-      <h1 className="text-start py-[65px] font-extrabold md:text-start md:py-[45px] md:font-semibold md:text-[30px] lg:text-start lg:py-[65px] lg:font-bold lg:text-[38px] sm:px-[24px] sm:text-[14px] sm:font-bold sm:mb-[-40px] sm:leading-[24px]">
+    <div className="w-full relative md:w-full lg:w-full sm:w-full">
+      <h1 className="text-start py-[65px] font-extrabold md:text-start md:py-[45px] md:px-[32px] md:font-semibold md:text-[30px] lg:text-start lg:py-[65px] lg:font-bold lg:text-[38px] sm:px-[24px] sm:text-[14px] sm:font-bold sm:mb-[-40px] sm:leading-[24px]">
         위치
       </h1>
-      <div id="map" className="w-full h-full"></div>
+      <div id="map" className="w-full h-[500px] md:h-[400px] lg:h-[500px] sm:h-[300px]"></div>
     </div>
   );
 };


### PR DESCRIPTION

![cvb23asd](https://github.com/user-attachments/assets/26a7754c-71cd-4ae9-9b8f-25a89837b814)
![vbvbnaas1](https://github.com/user-attachments/assets/d30bc10d-8188-4fc4-8c62-acf573bd5a81)




부모 div에 잘못된 w가 있어서 쏠림 현상이 있던걸 고치고

기존에 지저분했던거 좀 정리좀 했습니다

contentDetail의 title은 겹치기 때문에 contentTypeId로 바꾸고 각숫자에 맞는 텍스트로 불러오도록 변경했습니다

예시 12= 관광지

페이지 네이션은 2페이지 미만이면 prev next가 안보이게 했습니다

이게 어려울줄 알았는데 기존 코드에서 논리연산자만 살짝 바꿔 써주면 되더랍니다..급하면 방법을 다 찾나봅니다

좀 더 디테일한 부분은 한 번 더 업데이트 해볼게요 일단 ut중이라 고친거부터 반영해보겠습니다