### PR TITLE
Feat#108 소개페이지 에러 수정 외

### DIFF
--- a/src/app/(main)/about/page.tsx
+++ b/src/app/(main)/about/page.tsx
@@ -38,7 +38,10 @@ const AboutPage = () => {
     return <div className="text-center py-10 text-red-500">데이터를 불러오는 중 오류가 발생했습니다.</div>;
   }
 
-  const slicedData = data.slice(0, ITEMS_PER_PAGE);
+  const filteredData = selectedCategory === "전체" ? data : data.filter((post) => post.category === selectedCategory);
+
+  const slicedData = filteredData.slice(0, ITEMS_PER_PAGE);
+
   return (
     <main className=" w-auto h-auto justify-items-center min-w-[300px]">
       <section className=" w-auto h-auto bg-secondary-700 justify-items-center">

--- a/src/app/(main)/detail/[contentId]/page.tsx
+++ b/src/app/(main)/detail/[contentId]/page.tsx
@@ -11,8 +11,10 @@ import KakaoMap from "@/components/detailpage/KakaoMap";
 import ShareButtonWithModal from "@/components/detailpage/share/ShareButtonWithModal";
 import { useContentData } from "@/hooks/detailpage/useContentData";
 import { parseHTMLString } from "@/utils/detailpage/StringUtils";
+import { useUserStore } from "@/zustand/userStore";
 
 const DetailPage = () => {
+  const { id: userId } = useUserStore();
   const { contentId, contentItemData, isPending: pendingContentItem, error: contentItemError } = useContentData();
   const {
     firstimage: imageUrl,
@@ -58,6 +60,7 @@ const DetailPage = () => {
             contentTypeId={contentTypeId || ""}
             addr1={addr1 || ""}
             tel={tel || ""}
+            userId={userId || ""}
           />
 
           <div>

--- a/src/components/detailpage/DetailPageLikeButton.tsx
+++ b/src/components/detailpage/DetailPageLikeButton.tsx
@@ -49,7 +49,7 @@ const DetailPageLikeButton: React.FC<LikeButtonProps> = ({ contentId, imageUrl, 
   }
 
   return (
-    <button onClick={handleLikeButton} disabled={!userId}>
+    <button onClick={handleLikeButton}>
       <Image
         src={likeImage}
         alt={liked ? "Unlike" : "Like"}

--- a/src/components/detailpage/DetailPageLikeButton.tsx
+++ b/src/components/detailpage/DetailPageLikeButton.tsx
@@ -1,15 +1,9 @@
 "use client";
 
-import { useModal } from "@/context/modal.context";
-import { useLikes } from "@/hooks/detailpage/useLikes";
-import { Likes } from "@/types/Likes.types";
-import { createClient } from "@/utils/supabase/client";
+import { useHandleLikeButton } from "@/hooks/detailpage/useHandleLikeButton";
 import { useUserStore } from "@/zustand/userStore";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
 import Image from "next/image";
-import React, { useEffect, useState } from "react";
-
-const supabase = createClient();
+import React from "react";
 
 interface LikeButtonProps {
   contentId: string;
@@ -18,152 +12,25 @@ interface LikeButtonProps {
   title: string;
   addr1: string;
   tel: string;
-}
-
-interface ContextType {
-  previousLikes: Likes[] | undefined;
+  userId: string;
 }
 
 const DetailPageLikeButton: React.FC<LikeButtonProps> = ({ contentId, imageUrl, contentTypeId, title, addr1, tel }) => {
-  const [liked, setLiked] = useState<Boolean>(false);
-  const modal = useModal();
-
-  const queryClient = useQueryClient();
-
   const { id: userId } = useUserStore();
-
-  const { isPending, isError, data } = useLikes(contentId, userId);
-
-  const deleteMutation = useMutation({
-    mutationFn: async (userId: string) => {
-      const { error } = await supabase.from("Likes").delete().match({ user_id: userId, content_id: contentId });
-      if (error) {
-        throw new Error(error.message);
-      }
-    },
-    onSuccess: () => {
-      modal.open({
-        title: "알림",
-        content: (
-          <div className="text-center">
-            <p>좋아요가 취소되었습니다.</p>
-          </div>
-        ),
-      });
-      queryClient.invalidateQueries({ queryKey: ["likes", contentId] });
-    },
-    onError: (error) => {
-      modal.open({
-        title: "에러",
-        content: (
-          <div className="text-center">
-            <p>좋아요 취소 중 에러가 발생했습니다.</p>
-            <p>{error.message}</p>
-          </div>
-        ),
-      });
-    },
+  const { liked, isError, isPending, data, handleLikeButton } = useHandleLikeButton({
+    contentId,
+    imageUrl,
+    contentTypeId,
+    title,
+    addr1,
+    tel,
+    userId: userId || "",
   });
 
-  const addMutation = useMutation<Likes, Error, Partial<Likes>, ContextType>({
-    mutationFn: async (variables) => {
-      if (!userId) {
-        modal.open({
-          title: "알림",
-          content: (
-            <div className="text-center">
-              <p>로그인 후 좋아요를 누를 수 있습니다.</p>
-            </div>
-          ),
-        });
-        throw new Error();
-      }
-
-      const { data, error } = await supabase
-        .from("Likes")
-        .insert([
-          {
-            user_id: userId,
-            content_id: contentId,
-            image_url: imageUrl,
-            content_type_id: contentTypeId,
-            title: title,
-            address: addr1,
-            tel: tel,
-          },
-        ])
-        .single();
-
-      if (error) {
-        modal.open({
-          title: "에러",
-          content: (
-            <div className="text-center">
-              <p>에러가 발생했습니다</p>
-            </div>
-          ),
-        });
-        throw new Error();
-      }
-
-      if (!data) {
-        modal.open({
-          title: "에러",
-          content: (
-            <div className="text-center">
-              <p>데이터가 없습니다</p>
-            </div>
-          ),
-        });
-        throw new Error();
-      }
-
-      return data as Likes;
-    },
-    onMutate: async (variables) => {
-      await queryClient.cancelQueries({ queryKey: ["likes", contentId] });
-      const previousLikes = queryClient.getQueryData<Likes[]>(["likes", contentId]);
-
-      if (previousLikes) {
-        queryClient.setQueryData<Likes[]>(["likes", contentId], [...previousLikes, variables as Likes]);
-      } else {
-        queryClient.setQueryData<Likes[]>(["likes", contentId], [variables as Likes]);
-      }
-
-      return { previousLikes };
-    },
-
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ["likes", contentId] });
-      modal.open({
-        title: "알림",
-        content: (
-          <div className="text-center">
-            <p>장소가 나의 공간에</p>
-            <p>추가되었습니다.</p>
-          </div>
-        ),
-      });
-    },
-    onError: (error) => {
-      modal.open({
-        title: "에러",
-        content: (
-          <div className="text-center">
-            <p>좋아요 등록 중 에러가 발생했습니다.</p>
-            <p>{error.message}</p>
-          </div>
-        ),
-      });
-    },
-  });
-
-  useEffect(() => {
-    if (data) {
-      const result = data.find((item) => item.user_id === userId);
-      setLiked(!!result);
-    }
-  }, [data, userId]);
+  const likeImage =
+    data && data.find((item) => item.user_id === userId)
+      ? "/assets/images/successLikeIcon.svg"
+      : "/assets/images/defaultLikeIcon.svg";
 
   if (isPending) {
     return (
@@ -180,41 +47,6 @@ const DetailPageLikeButton: React.FC<LikeButtonProps> = ({ contentId, imageUrl, 
   if (isError) {
     return <div>에러가 감지되었습니다....</div>;
   }
-
-  const handleLikeButton = async (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    event?.stopPropagation();
-    try {
-      if (liked) {
-        deleteMutation.mutate(userId!);
-      } else {
-        addMutation.mutate({
-          user_id: userId,
-          content_id: contentId,
-          image_url: imageUrl,
-          content_type_id: contentTypeId,
-          title: title,
-          address: addr1,
-          tel: tel,
-        });
-      }
-      setLiked((prevLiked) => !prevLiked);
-    } catch (error) {
-      modal.open({
-        title: "에러",
-        content: (
-          <div className="text-center">
-            <p>좋아요 상태 업데이트를 실패했습니다.</p>
-            <p>{(error as Error).message}</p>
-          </div>
-        ),
-      });
-    }
-  };
-
-  const likeImage =
-    data && data.find((item) => item.user_id === userId)
-      ? "/assets/images/successLikeIcon.svg"
-      : "/assets/images/defaultLikeIcon.svg";
 
   return (
     <button onClick={handleLikeButton} disabled={!userId}>

--- a/src/components/location/Map.tsx
+++ b/src/components/location/Map.tsx
@@ -1,9 +1,10 @@
-import { TouristSpot, useTouristSpots } from "@/hooks/useTouristSpots";
-import { useLocationStore } from "@/zustand/locationStore";
-import { useEffect, useRef, useState } from "react";
-import Image from "next/image";
 import LoadingPage from "@/app/loading";
+import { TouristSpot, useTouristSpots } from "@/hooks/useTouristSpots";
 import { convertToHttps } from "@/utils/convertToHttps";
+import { useLocationStore } from "@/zustand/locationStore";
+import { useUserStore } from "@/zustand/userStore";
+import Image from "next/image";
+import { useEffect, useRef, useState } from "react";
 import DetailPageLikeButton from "../detailpage/DetailPageLikeButton";
 
 const KAKAO_MAP_API = process.env.NEXT_PUBLIC_KAKAO_MAP_API_KEY;
@@ -29,6 +30,7 @@ const MapComponent: React.FC = () => {
   const [currentOverlay, setCurrentOverlay] = useState<kakao.maps.CustomOverlay | null>(null);
   const [previousCenter, setPreviousCenter] = useState<kakao.maps.LatLng | null>(null);
   const [previousLevel, setPreviousLevel] = useState<number | null>(null);
+  const { id: userId } = useUserStore();
 
   useEffect(() => {
     if (latitude === null || longitude === null) return;
@@ -249,6 +251,7 @@ const MapComponent: React.FC = () => {
                   contentTypeId={selectedSpot.contentTypeId || "12"}
                   addr1={selectedSpot.address || ""}
                   tel={selectedSpot.tel || ""}
+                  userId={userId || ""}
                 />
               </div>
 
@@ -303,6 +306,7 @@ const MapComponent: React.FC = () => {
                         addr1={spot.address || ""}
                         title={spot.title || ""}
                         tel={spot.tel || ""}
+                        userId={userId || ""}
                       />
                     </div>
                     <p className="text-secondary-700 text-[12px] lg:text-[14px]">{distance.toFixed(2)} km</p>

--- a/src/components/main/swiper/TravelSlider.tsx
+++ b/src/components/main/swiper/TravelSlider.tsx
@@ -1,23 +1,27 @@
 "use client";
 
+import { Likes } from "@/types/Likes.types";
 import { ApiInformation } from "@/types/Main";
+import { convertToHttps } from "@/utils/convertToHttps";
+import { useUserStore } from "@/zustand/userStore";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { convertToHttps } from "@/utils/convertToHttps";
+import { useEffect, useState } from "react";
 import { useMediaQuery } from "react-responsive";
+import SwiperCore from "swiper";
 import { A11y, Autoplay, Grid } from "swiper/modules";
 import { Swiper, SwiperSlide } from "swiper/react";
+import { useHandleLikeButtonSwiper } from "./../../../hooks/detailpage/useHandleLikeButtonSwiper";
 import TravelSwiperSkeleton from "./TravelSwiperSkeleton ";
-import SwiperCore from "swiper";
-import { useCallback, useEffect, useState } from "react";
-import { Likes } from "@/types/Likes.types";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useModal } from "@/context/modal.context";
-import { useUserStore } from "@/zustand/userStore";
-import { useLikes } from "@/hooks/detailpage/useLikes";
-import { createClient } from "@/utils/supabase/client";
 interface MainTravelSliderProps {
   travel: ApiInformation[];
+  contentId: string;
+  imageUrl: string;
+  contentTypeId: string;
+  title: string;
+  addr1: string;
+  tel: string;
+  userId: string;
 }
 interface ContextType {
   previousLikes: Likes[] | undefined;
@@ -27,219 +31,28 @@ export const MainTravelSlider: React.FC<MainTravelSliderProps> = ({ travel }) =>
   const isLgScreen = useMediaQuery({ minWidth: 1024 });
   const [swiper, setSwiper] = useState<SwiperCore | null>(null);
   const router = useRouter();
-  const supabase = createClient();
-  const queryClient = useQueryClient();
+
   const { id: userId } = useUserStore();
-  const modal = useModal();
+
   const item = travel[0] as ApiInformation;
-  const [likedStates, setLikedStates] = useState<Record<string, boolean>>({});
-  const { isPending, isError, data } = useLikes(item.contentid, userId);
 
-  const deleteMutation = useMutation({
-    mutationFn: async (userId: string) => {
-      const { error } = await supabase.from("Likes").delete().match({ user_id: userId, content_id: item.contentid });
-      if (error) {
-        throw new Error(error.message);
-      }
-    },
-    onSuccess: () => {
-      modal.open({
-        title: "알림",
-        content: (
-          <div className="text-center">
-            <p>좋아요가 취소되었습니다.</p>
-          </div>
-        ),
-      });
-      queryClient.invalidateQueries({ queryKey: ["likes", item.contentid] });
-    },
-    onError: (error) => {
-      modal.open({
-        title: "에러",
-        content: (
-          <div className="text-center">
-            <p>좋아요 취소 중 에러가 발생했습니다.</p>
-            <p>{error.message}</p>
-          </div>
-        ),
-      });
-    },
+  const { likedStates, isError, isPending, data, handleLikeButton } = useHandleLikeButtonSwiper({
+    travel,
+    contentId: item.contentid,
+    imageUrl: item.firstimage,
+    contentTypeId: item.contenttypeid,
+    title: item.title,
+    addr1: item.addr1,
+    tel: item.tel || "",
+    userId: userId || "",
   });
-
-  const addMutation = useMutation<Likes, Error, Partial<Likes>, ContextType>({
-    mutationFn: async (variables) => {
-      if (!userId) {
-        modal.open({
-          title: "알림",
-          content: (
-            <div className="text-center">
-              <p>로그인 후 좋아요를 누를 수 있습니다.</p>
-            </div>
-          ),
-        });
-
-        throw new Error();
-      }
-
-      const { data, error } = await supabase
-        .from("Likes")
-        .insert([
-          {
-            user_id: userId,
-            content_id: variables.content_id,
-            image_url: variables.image_url,
-            content_type_id: variables.content_type_id,
-            title: variables.title,
-            address: variables.address,
-            tel: variables.tel,
-          },
-        ])
-        .select()
-        .single();
-
-      if (error) {
-        throw new Error(error.message);
-      }
-
-      if (!data) {
-        modal.open({
-          title: "에러",
-          content: (
-            <div className="text-center">
-              <p>데이터가 없습니다.</p>
-            </div>
-          ),
-        });
-        throw new Error();
-      }
-
-      return data as Likes;
-    },
-
-    onMutate: async (variables) => {
-      await queryClient.cancelQueries({ queryKey: ["likes", variables.content_id] });
-      const previousLikes = queryClient.getQueryData<Likes[]>(["likes", variables.content_id]);
-
-      if (previousLikes) {
-        const newLikes = [...previousLikes, variables as Likes];
-        queryClient.setQueryData<Likes[]>(["likes", variables.content_id], newLikes);
-      } else {
-        queryClient.setQueryData<Likes[]>(["likes", variables.content_id], [variables as Likes]);
-      }
-
-      return { previousLikes };
-    },
-
-    onSettled: (variables) => {
-      modal.open({
-        title: "알림",
-        content: (
-          <div className="text-center">
-            <p>장소가 나의 공간에</p>
-            <p>추가되었습니다.</p>
-          </div>
-        ),
-      });
-      queryClient.invalidateQueries({ queryKey: ["likes", variables?.content_id] });
-    },
-
-    onError: (error, variables, context) => {
-      modal.open({
-        title: "에러",
-        content: (
-          <div className="text-center">
-            <p>좋아요 등록 중 에러가 발생했습니다.</p>
-            <p>{error.message}</p>
-          </div>
-        ),
-      });
-
-      if (context?.previousLikes) {
-        queryClient.setQueryData<Likes[]>(["likes", variables?.content_id], context.previousLikes);
-      }
-    },
-  });
-  const handleLikeButton = useCallback(
-    async (event: React.MouseEvent<HTMLButtonElement>) => {
-      event.stopPropagation();
-      const contentId = event.currentTarget.getAttribute("data-contentid"); // 클릭된 버튼의 contentId 가져오기
-
-      if (!contentId) {
-        modal.open({
-          title: "에러",
-          content: (
-            <div className="text-center">
-              <p>Content ID가 없습니다!</p>
-            </div>
-          ),
-        });
-
-        return;
-      }
-
-      try {
-        if (likedStates[contentId]) {
-          deleteMutation.mutate(userId!);
-        } else {
-          const item = travel.find((item) => item.contentid === contentId); // travel 배열에서 해당 contentId를 가진 item 찾기
-
-          if (!item) {
-            modal.open({
-              title: "에러",
-              content: (
-                <div className="text-center">
-                  <p>Item not found 에러</p>
-                </div>
-              ),
-            });
-            return;
-          }
-
-          addMutation.mutate({
-            user_id: userId!,
-            content_id: item.contentid,
-            image_url: item.firstimage,
-            content_type_id: item.contenttypeid,
-            title: item.title,
-            address: item.addr1,
-            tel: item.tel,
-          });
-        }
-
-        setLikedStates((prevStates) => ({
-          ...prevStates,
-          [contentId]: !prevStates[contentId],
-        }));
-      } catch (error) {
-        modal.open({
-          title: "에러",
-          content: (
-            <div className="text-center">
-              <p>좋아요 상태 업데이트를 실패했습니다.</p>
-              <p>{(error as Error).message}</p>
-            </div>
-          ),
-        });
-      }
-    },
-    [likedStates, addMutation, deleteMutation, userId, modal, travel],
-  );
 
   useEffect(() => {
     if (swiper) {
       swiper.update();
     }
   }, [isLgScreen, swiper]);
-  useEffect(() => {
-    if (data) {
-      const newLikedStates = travel.reduce((acc, item) => {
-        const result = data.find((like) => like.user_id === userId && like.content_id === item.contentid);
-        acc[item.contentid] = !!result;
-        return acc;
-      }, {} as Record<string, boolean>);
-      setLikedStates(newLikedStates);
-    }
-  }, [data, travel, userId]);
+
   if (isPending) {
     return <TravelSwiperSkeleton />;
   }
@@ -249,7 +62,7 @@ export const MainTravelSlider: React.FC<MainTravelSliderProps> = ({ travel }) =>
   }
 
   const likeImage =
-    data && data.find((like) => like.user_id === userId)
+    data && data.find((like: { user_id: string | null }) => like.user_id === userId)
       ? "/assets/images/successLikeIcon.svg"
       : "/assets/images/defaultLikeIcon.svg";
 

--- a/src/components/main/swiper/TravelSlider.tsx
+++ b/src/components/main/swiper/TravelSlider.tsx
@@ -61,11 +61,6 @@ export const MainTravelSlider: React.FC<MainTravelSliderProps> = ({ travel }) =>
     return <div>에러가 감지되었습니다....</div>;
   }
 
-  const likeImage =
-    data && data.find((like: { user_id: string | null }) => like.user_id === userId)
-      ? "/assets/images/successLikeIcon.svg"
-      : "/assets/images/defaultLikeIcon.svg";
-
   return (
     <Swiper
       modules={[Grid, A11y, Autoplay]}
@@ -117,7 +112,6 @@ export const MainTravelSlider: React.FC<MainTravelSliderProps> = ({ travel }) =>
                   <button
                     data-contentid={item.contentid}
                     onClick={(event) => handleLikeButton(event)}
-                    disabled={!userId}
                     className="absolute top-2 right-2 opacity-70"
                   >
                     <Image

--- a/src/components/maindetail/TravelCard.tsx
+++ b/src/components/maindetail/TravelCard.tsx
@@ -39,7 +39,7 @@ export const TravelCard: React.FC<TravelCardProps> = ({ item }) => {
         {item.firstimage ? (
           <div>
             <Image src={item.firstimage} alt={item.title} layout="fill" objectFit="cover" className="rounded-t-[8px]" />
-            <button onClick={handleLikeButton} disabled={!userId} className="absolute top-2 right-2">
+            <button onClick={handleLikeButton} className="absolute top-2 right-2">
               <Image
                 src={likeImage}
                 alt={liked ? "Unlike" : "Like"}

--- a/src/components/maindetail/TravelCard.tsx
+++ b/src/components/maindetail/TravelCard.tsx
@@ -1,192 +1,29 @@
-import { useModal } from "@/context/modal.context"; // Modal context import
-import { useLikes } from "@/hooks/detailpage/useLikes";
-import { Likes } from "@/types/Likes.types";
+import { useHandleLikeButton } from "@/hooks/detailpage/useHandleLikeButton";
 import { ApiInformation } from "@/types/Main";
 import { createClient } from "@/utils/supabase/client";
 import { useUserStore } from "@/zustand/userStore";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
-import { SkeletonCard } from "./SkeletonCard";
 
 const supabase = createClient();
 
 interface TravelCardProps {
   item: ApiInformation;
-  contentId: string;
-  imageUrl: string;
-  contentTypeId: string;
-  title: string;
-  addr1: string;
-  tel: string;
-  user_id: string;
 }
 
-interface ContextType {
-  previousLikes: Likes[] | undefined;
-}
 export const TravelCard: React.FC<TravelCardProps> = ({ item }) => {
-  const [liked, setLiked] = useState<Boolean>(false);
   const router = useRouter();
-  const queryClient = useQueryClient();
-  const modal = useModal();
   const { id: userId } = useUserStore();
 
-  const { isPending, isError, data } = useLikes(item.contentid, userId);
-
-  const deleteMutation = useMutation({
-    mutationFn: async (userId: string) => {
-      const { error } = await supabase.from("Likes").delete().match({ user_id: userId, content_id: item.contentid });
-      if (error) {
-        throw new Error(error.message);
-      }
-    },
-    onSuccess: () => {
-      modal.open({
-        title: "알림",
-        content: (
-          <div className="text-center">
-            <p>좋아요가 취소되었습니다.</p>
-          </div>
-        ),
-      });
-      queryClient.invalidateQueries({ queryKey: ["likes", item.contentid] });
-    },
-    onError: (error) => {
-      modal.open({
-        title: "에러",
-        content: (
-          <div className="text-center">
-            <p>좋아요 취소 중 에러가 발생했습니다.</p>
-            <p>{error.message}</p>
-          </div>
-        ),
-      });
-    },
+  const { liked, isError, data, isPending, handleLikeButton } = useHandleLikeButton({
+    contentId: item.contentid || "",
+    imageUrl: item.firstimage || "",
+    contentTypeId: item.contenttypeid || "",
+    title: item.title || "",
+    addr1: item.addr1 || "",
+    tel: item.tel || "",
+    userId: userId || "",
   });
-
-  const addMutation = useMutation<Likes, Error, Partial<Likes>, ContextType>({
-    mutationFn: async (variables) => {
-      if (!userId) {
-        modal.open({
-          title: "알림",
-          content: (
-            <div className="text-center">
-              <p>로그인 후 좋아요를 누를 수 있습니다.</p>
-            </div>
-          ),
-        });
-        throw new Error("세션 정보가 없습니다.");
-      }
-
-      const { data, error } = await supabase
-        .from("Likes")
-        .insert([
-          {
-            user_id: userId,
-            content_id: item.contentid,
-            image_url: item.firstimage,
-            content_type_id: item.contenttypeid,
-            title: item.title,
-            address: item.addr1,
-            tel: item.tel,
-          },
-        ])
-        .single();
-
-      if (error) {
-        throw new Error(error.message);
-      }
-
-      if (!data) {
-        throw new Error("좋아요 추가에 실패했습니다.");
-      }
-
-      return data as Likes;
-    },
-    onMutate: async (variables) => {
-      await queryClient.cancelQueries({ queryKey: ["likes", item.contentid] });
-      const previousLikes = queryClient.getQueryData<Likes[]>(["likes", item.contentid]);
-
-      if (previousLikes) {
-        queryClient.setQueryData<Likes[]>(["likes", item.contentid], [...previousLikes, variables as Likes]);
-      } else {
-        queryClient.setQueryData<Likes[]>(["likes", item.contentid], [variables as Likes]);
-      }
-
-      return { previousLikes };
-    },
-
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ["likes", item.contentid] });
-      modal.open({
-        title: "알림",
-        content: (
-          <div className="text-center">
-            <p>장소가 나의 공간에</p>
-            <p>추가되었습니다.</p>
-          </div>
-        ),
-      });
-    },
-    onError: (error) => {
-      modal.open({
-        title: "에러",
-        content: (
-          <div className="text-center">
-            <p>좋아요 등록 중 에러가 발생했습니다.</p>
-            <p>{error.message}</p>
-          </div>
-        ),
-      });
-    },
-  });
-
-  useEffect(() => {
-    if (data) {
-      const result = data.find((like) => like.user_id === userId);
-      setLiked(!!result);
-    }
-  }, [data, userId]);
-
-  if (isPending) {
-    return <SkeletonCard />;
-  }
-
-  if (isError) {
-    return <div>에러가 감지되었습니다....</div>;
-  }
-
-  const handleLikeButton = async (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.stopPropagation();
-    try {
-      if (liked) {
-        deleteMutation.mutate(userId!);
-      } else {
-        addMutation.mutate({
-          user_id: userId,
-          content_id: item.contentid,
-          image_url: item.firstimage,
-          content_type_id: item.contenttypeid,
-          title: item.title,
-          address: item.addr1,
-          tel: item.tel,
-        });
-      }
-      setLiked((prevLiked) => !prevLiked);
-    } catch (error) {
-      modal.open({
-        title: "에러",
-        content: (
-          <div className="text-center">
-            <p>좋아요 상태 업데이트를 실패했습니다.</p>
-            <p>{(error as Error).message}</p>
-          </div>
-        ),
-      });
-    }
-  };
 
   const likeImage =
     data && data.find((like) => like.user_id === userId)

--- a/src/hooks/detailpage/useHandleLikeButton.ts
+++ b/src/hooks/detailpage/useHandleLikeButton.ts
@@ -1,0 +1,154 @@
+import { useModal } from "@/context/modal.context";
+import { Likes } from "@/types/Likes.types";
+import { createClient } from "@/utils/supabase/client";
+import { useUserStore } from "@/zustand/userStore";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import React, { useEffect, useState } from "react";
+import { useLikes } from "./useLikes";
+
+const supabase = createClient();
+
+interface LikeButtonProps {
+  contentId: string;
+  imageUrl: string;
+  contentTypeId: string;
+  title: string;
+  addr1: string;
+  tel: string;
+  userId: string;
+}
+
+interface ContextType {
+  previousLikes: Likes[] | undefined;
+}
+
+export const useHandleLikeButton = ({ contentId, imageUrl, contentTypeId, title, addr1, tel }: LikeButtonProps) => {
+  const [liked, setLiked] = useState<Boolean>(false);
+  const modal = useModal();
+  const queryClient = useQueryClient();
+  const { id: userId } = useUserStore();
+  const { isPending, isError, data } = useLikes(contentId, userId);
+
+  const deleteMutation = useMutation({
+    mutationFn: async (userId: string) => {
+      const { error } = await supabase.from("Likes").delete().match({ user_id: userId, content_id: contentId });
+      if (error) {
+        throw new Error(error.message);
+      }
+    },
+    onSuccess: () => {
+      modal.open({
+        title: "알림",
+        content: "좋아요가 취소되었습니다",
+      });
+
+      queryClient.invalidateQueries({ queryKey: ["likes", contentId] });
+    },
+    onError: (error) => {
+      modal.open({
+        title: "에러",
+        content: "좋아요 취소 중 에러가 발생했습니다.",
+      });
+    },
+  });
+
+  const addMutation = useMutation<Likes, Error, Partial<Likes>, ContextType>({
+    mutationFn: async (variables) => {
+      if (!userId) {
+        modal.open({
+          title: "알림",
+          content: "로그인 후 좋아요를 누를 수 있습니다.",
+        });
+        throw new Error();
+      }
+
+      const { data, error } = await supabase
+        .from("Likes")
+        .insert([
+          {
+            user_id: userId,
+            content_id: contentId,
+            image_url: imageUrl,
+            content_type_id: contentTypeId,
+            title: title,
+            address: addr1,
+            tel: tel,
+          },
+        ])
+        .single();
+
+      if (error) {
+        modal.open({
+          title: "에러",
+          content: "에러가 발생했습니다.",
+        });
+        throw new Error();
+      }
+
+      if (!data) {
+        modal.open({
+          title: "에러",
+          content: "데이터가 없습니다.",
+        });
+        throw new Error();
+      }
+
+      return data as Likes;
+    },
+    onMutate: async (variables) => {
+      await queryClient.cancelQueries({ queryKey: ["likes", contentId] });
+      const previousLikes = queryClient.getQueryData<Likes[]>(["likes", contentId]);
+
+      if (previousLikes) {
+        queryClient.setQueryData<Likes[]>(["likes", contentId], [...previousLikes, variables as Likes]);
+      } else {
+        queryClient.setQueryData<Likes[]>(["likes", contentId], [variables as Likes]);
+      }
+
+      return { previousLikes };
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["likes", contentId] });
+      modal.open({
+        title: "알림",
+        content: "나의 공간에 추가되었습니다.",
+      });
+    },
+    onError: (error) => {
+      modal.open({
+        title: "에러",
+        content: "좋아요 등록 중 에러가 발생했습니다.",
+      });
+    },
+  });
+
+  const handleLikeButton = async (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    event?.stopPropagation();
+    try {
+      if (liked) {
+        deleteMutation.mutate(userId!);
+      } else {
+        addMutation.mutate({
+          user_id: userId,
+          content_id: contentId,
+          image_url: imageUrl,
+          content_type_id: contentTypeId,
+          title: title,
+          address: addr1,
+          tel: tel,
+        });
+      }
+      setLiked((prevLiked) => !prevLiked);
+    } catch (error) {}
+  };
+
+  useEffect(() => {
+    if (data) {
+      const result = data.find((item) => item.user_id === userId);
+      setLiked(!!result);
+    }
+  }, [data, userId]);
+
+  return { liked, isError, isPending, data, handleLikeButton };
+};

--- a/src/hooks/detailpage/useHandleLikeButton.ts
+++ b/src/hooks/detailpage/useHandleLikeButton.ts
@@ -47,21 +47,13 @@ export const useHandleLikeButton = ({ contentId, imageUrl, contentTypeId, title,
     onError: (error) => {
       modal.open({
         title: "에러",
-        content: "좋아요 취소 중 에러가 발생했습니다.",
+        content: "취소 중 에러가 발생했습니다.",
       });
     },
   });
 
   const addMutation = useMutation<Likes, Error, Partial<Likes>, ContextType>({
     mutationFn: async (variables) => {
-      if (!userId) {
-        modal.open({
-          title: "알림",
-          content: "로그인 후 좋아요를 누를 수 있습니다.",
-        });
-        throw new Error();
-      }
-
       const { data, error } = await supabase
         .from("Likes")
         .insert([
@@ -118,7 +110,7 @@ export const useHandleLikeButton = ({ contentId, imageUrl, contentTypeId, title,
     onError: (error) => {
       modal.open({
         title: "에러",
-        content: "좋아요 등록 중 에러가 발생했습니다.",
+        content: "에러가 발생했습니다.",
       });
     },
   });
@@ -126,6 +118,13 @@ export const useHandleLikeButton = ({ contentId, imageUrl, contentTypeId, title,
   const handleLikeButton = async (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     event?.stopPropagation();
     try {
+      if (!userId) {
+        modal.open({
+          title: "알림",
+          content: "로그인 후 이용가능합니다.",
+        });
+        return;
+      }
       if (liked) {
         deleteMutation.mutate(userId!);
       } else {

--- a/src/hooks/detailpage/useHandleLikeButtonSwiper.ts
+++ b/src/hooks/detailpage/useHandleLikeButtonSwiper.ts
@@ -1,0 +1,204 @@
+import { useModal } from "@/context/modal.context";
+import { Likes } from "@/types/Likes.types";
+import { ApiInformation } from "@/types/Main";
+import { createClient } from "@/utils/supabase/client";
+import { useUserStore } from "@/zustand/userStore";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useState } from "react";
+import { useLikes } from "./useLikes";
+
+interface MainTravelSliderProps {
+  travel: ApiInformation[];
+  contentId: string;
+  imageUrl: string;
+  contentTypeId: string;
+  title: string;
+  addr1: string;
+  tel: string;
+  userId: string;
+}
+
+interface ContextType {
+  previousLikes: Likes[] | undefined;
+}
+
+export const useHandleLikeButtonSwiper = ({
+  travel,
+  contentId,
+  imageUrl,
+  contentTypeId,
+  title,
+  addr1,
+  tel,
+}: MainTravelSliderProps) => {
+  const modal = useModal();
+
+  const supabase = createClient();
+  const [likedStates, setLikedStates] = useState<Record<string, boolean>>({});
+  const queryClient = useQueryClient();
+  const { id: userId } = useUserStore();
+  const item = travel[0] as ApiInformation;
+  const { isPending, isError, data } = useLikes(travel[0].contentid, userId);
+
+  const deleteMutation = useMutation({
+    mutationFn: async (userId: string) => {
+      const { error } = await supabase.from("Likes").delete().match({ user_id: userId, content_id: item.contentid });
+      if (error) {
+        throw new Error(error.message);
+      }
+    },
+    onSuccess: () => {
+      modal.open({
+        title: "알림",
+        content: "좋아요가 취소되었습니다.",
+      });
+      queryClient.invalidateQueries({ queryKey: ["likes", item.contentid] });
+    },
+    onError: (error) => {
+      modal.open({
+        title: "에러",
+        content: "좋아요 취소 중 에러가 발생했습니다.",
+      });
+    },
+  });
+
+  const addMutation = useMutation<Likes, Error, Partial<Likes>, ContextType>({
+    mutationFn: async (variables) => {
+      if (!userId) {
+        modal.open({
+          title: "알림",
+          content: "로그인 후 좋아요를 누를 수 있습니다.",
+        });
+
+        throw new Error();
+      }
+
+      const { data, error } = await supabase
+        .from("Likes")
+        .insert([
+          {
+            user_id: userId,
+            content_id: variables.content_id,
+            image_url: variables.image_url,
+            content_type_id: variables.content_type_id,
+            title: variables.title,
+            address: variables.address,
+            tel: variables.tel,
+          },
+        ])
+        .select()
+        .single();
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      if (!data) {
+        modal.open({
+          title: "에러",
+          content: "데이터가 없습니다.",
+        });
+        throw new Error();
+      }
+
+      return data as Likes;
+    },
+
+    onMutate: async (variables) => {
+      await queryClient.cancelQueries({ queryKey: ["likes", variables.content_id] });
+      const previousLikes = queryClient.getQueryData<Likes[]>(["likes", variables.content_id]);
+
+      if (previousLikes) {
+        const newLikes = [...previousLikes, variables as Likes];
+        queryClient.setQueryData<Likes[]>(["likes", variables.content_id], newLikes);
+      } else {
+        queryClient.setQueryData<Likes[]>(["likes", variables.content_id], [variables as Likes]);
+      }
+
+      return { previousLikes };
+    },
+
+    onSettled: (variables) => {
+      modal.open({
+        title: "알림",
+        content: "나의 공간에 추가되었습니다.",
+      });
+      queryClient.invalidateQueries({ queryKey: ["likes", variables?.content_id] });
+    },
+
+    onError: (error, variables, context) => {
+      modal.open({
+        title: "에러",
+        content: "좋아요 등록 중 에러가 발생했습니다.",
+      });
+
+      if (context?.previousLikes) {
+        queryClient.setQueryData<Likes[]>(["likes", variables?.content_id], context.previousLikes);
+      }
+    },
+  });
+  const handleLikeButton = useCallback(
+    async (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      const contentId = event.currentTarget.getAttribute("data-contentid");
+
+      if (!contentId) {
+        modal.open({
+          title: "에러",
+          content: "Content ID가 없습니다!",
+        });
+
+        return;
+      }
+
+      try {
+        if (likedStates[contentId]) {
+          deleteMutation.mutate(userId!);
+        } else {
+          const item = travel.find((item) => item.contentid === contentId);
+
+          if (!item) {
+            modal.open({
+              title: "에러",
+              content: "Item not found 에러",
+            });
+            return;
+          }
+
+          addMutation.mutate({
+            user_id: userId!,
+            content_id: item.contentid,
+            image_url: item.firstimage,
+            content_type_id: item.contenttypeid,
+            title: item.title,
+            address: item.addr1,
+            tel: item.tel,
+          });
+        }
+
+        setLikedStates((prevStates) => ({
+          ...prevStates,
+          [contentId]: !prevStates[contentId],
+        }));
+      } catch (error) {
+        modal.open({
+          title: "에러",
+          content: "좋아요 상태 업데이트를 실패했습니다.",
+        });
+      }
+    },
+    [likedStates, addMutation, deleteMutation, userId, modal, travel],
+  );
+
+  useEffect(() => {
+    if (data) {
+      const newLikedStates = travel.reduce((acc, item) => {
+        const result = data.find((like) => like.user_id === userId && like.content_id === item.contentid);
+        acc[item.contentid] = !!result;
+        return acc;
+      }, {} as Record<string, boolean>);
+      setLikedStates(newLikedStates);
+    }
+  }, [data, travel, userId]);
+  return { likedStates, isError, isPending, data, handleLikeButton };
+};

--- a/src/hooks/detailpage/useHandleLikeButtonSwiper.ts
+++ b/src/hooks/detailpage/useHandleLikeButtonSwiper.ts
@@ -57,22 +57,13 @@ export const useHandleLikeButtonSwiper = ({
     onError: (error) => {
       modal.open({
         title: "에러",
-        content: "좋아요 취소 중 에러가 발생했습니다.",
+        content: "취소 중 에러가 발생했습니다.",
       });
     },
   });
 
   const addMutation = useMutation<Likes, Error, Partial<Likes>, ContextType>({
     mutationFn: async (variables) => {
-      if (!userId) {
-        modal.open({
-          title: "알림",
-          content: "로그인 후 좋아요를 누를 수 있습니다.",
-        });
-
-        throw new Error();
-      }
-
       const { data, error } = await supabase
         .from("Likes")
         .insert([
@@ -129,7 +120,7 @@ export const useHandleLikeButtonSwiper = ({
     onError: (error, variables, context) => {
       modal.open({
         title: "에러",
-        content: "좋아요 등록 중 에러가 발생했습니다.",
+        content: "에러가 발생했습니다.",
       });
 
       if (context?.previousLikes) {
@@ -152,6 +143,13 @@ export const useHandleLikeButtonSwiper = ({
       }
 
       try {
+        if (!userId) {
+          modal.open({
+            title: "알림",
+            content: "로그인 후 이용가능합니다.",
+          });
+          return;
+        }
         if (likedStates[contentId]) {
           deleteMutation.mutate(userId!);
         } else {


### PR DESCRIPTION
에러 수정

카테고리 텝이 작동 안했던 이유:

데이터를 3개만 가져오게 data 변수를 slicedData로 구조분해 할당으로 적용하는 것은 좋았으나

그것이 selectedCategory(카테고리 탭 변수) 까지 반영이 되지 않았음.

selectedCategory를 filteredData로 구조분해할당 후 slicedData에 구조분해할당.

+
좋아요 커스텀 훅으로 바꿨습니다. 심적인 여유를 가지고 다시 강의도 찾아보고 하니 됩니다...
로그인 안한 상태에서 클릭가능하고 모달창 나오도록 수정했습니다 로그인 페이지로 이동까지는 안해뒀습니다. 